### PR TITLE
🐛 Fix:entrypoint.sh修正

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,5 +4,10 @@ set -e
 # Remove a potentially pre-existing server.pid for Rails.
 rm -f /myapp/tmp/pids/server.pid
 
+if [ "${RAILS_ENV}" = "production" ]
+then
+    bundle exec rails assets:precompile
+fi
+
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"


### PR DESCRIPTION
# 概要
herokuのデプロイログにて以下のエラーに対応した。
`ActionView::Template::Error (The asset "application.css" is not present in the asset pipeline.`

## entrypoint.shを修正
本番環境でのコンパイルがうまくいっていないと考え、
本番環境でRailsアプリが起動される場合に事前コンパイルされるように処理を追加。