### PR TITLE
13 spot検索機能 google map api導入

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 # Ignore all environment files (except templates).
 /.env*
 !/.env*.erb
+.env
 
 # Ignore all logfiles and tempfiles.
 /log/*

--- a/Gemfile
+++ b/Gemfile
@@ -63,4 +63,7 @@ group :development do
   # gem "spring"
 end
 
+#その他
+gem 'dotenv-rails'
+
 

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,21 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+# google_places_api
+gem 'google_places'
+
+# javasctipt
+gem 'gon'
+
+# debug
+gem 'pry-rails'
+
+# Geolocation
+gem 'geokit-rails'
+
+# Geocoding
+gem 'geocoder'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ]
@@ -63,7 +78,7 @@ group :development do
   # gem "spring"
 end
 
-#その他
+# security
 gem 'dotenv-rails'
 
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,7 @@ GEM
     bootsnap (1.18.3)
       msgpack (~> 1.2)
     builder (3.2.4)
+    coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
     crass (1.0.6)
@@ -96,8 +97,23 @@ GEM
       railties (>= 6.1)
     drb (2.2.1)
     erubi (1.12.0)
+    geocoder (1.8.2)
+    geokit (1.14.0)
+    geokit-rails (2.5.0)
+      geokit (~> 1.5)
+      rails (>= 3.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
+    gon (6.4.0)
+      actionpack (>= 3.0.20)
+      i18n (>= 0.7)
+      multi_json
+      request_store (>= 1.0)
+    google_places (2.0.0)
+      httparty (>= 0.13.1)
+    httparty (0.21.0)
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
     i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
@@ -118,9 +134,12 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    method_source (1.1.0)
     mini_mime (1.1.5)
     minitest (5.22.3)
     msgpack (1.7.2)
+    multi_json (1.15.0)
+    multi_xml (0.6.0)
     mutex_m (0.2.0)
     net-imap (0.4.10)
       date
@@ -137,6 +156,11 @@ GEM
     nokogiri (1.16.4-x86_64-linux)
       racc (~> 1.4)
     pg (1.5.6)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     psych (5.1.2)
       stringio
     puma (6.4.2)
@@ -184,6 +208,8 @@ GEM
       psych (>= 4.0.0)
     reline (0.5.1)
       io-console (~> 0.5)
+    request_store (1.6.0)
+      rack (>= 1.4)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -222,9 +248,14 @@ DEPENDENCIES
   cssbundling-rails
   debug
   dotenv-rails
+  geocoder
+  geokit-rails
+  gon
+  google_places
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
+  pry-rails
   puma (>= 5.0)
   rails (~> 7.1.3, >= 7.1.3.2)
   sprockets-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,10 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    dotenv (3.1.0)
+    dotenv-rails (3.1.0)
+      dotenv (= 3.1.0)
+      railties (>= 6.1)
     drb (2.2.1)
     erubi (1.12.0)
     globalid (1.2.1)
@@ -217,6 +221,7 @@ DEPENDENCIES
   bootsnap
   cssbundling-rails
   debug
+  dotenv-rails
   jbuilder
   jsbundling-rails
   pg (~> 1.1)

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,0 +1,4 @@
+class SpotsController < ApplicationController
+
+  def map; end
+end

--- a/app/helpers/spots_helper.rb
+++ b/app/helpers/spots_helper.rb
@@ -1,0 +1,2 @@
+module SpotsHelper
+end

--- a/app/views/spots/map.html.erb
+++ b/app/views/spots/map.html.erb
@@ -1,0 +1,74 @@
+<h2>Google Map Test</h2>
+<input id="address" type="textbox" value="">
+<input type="button" value="送信" onclick="codeAddress()">
+<input type="button" value="現在地を表示" onclick="showCurrentLocation()">
+<div id="latlngDisplay">ここに緯度、経緯が表示される</div>
+<div id="addressDisplay">ここに住所が表示される</div>
+<div id="map"></div>
+
+<style>
+#map {
+  height: 600px;
+  width: 600px;
+}
+</style>
+
+<script>
+let map, marker;
+
+const latlngDis = document.getElementById('latlngDisplay');
+const addressDis = document.getElementById('addressDisplay');
+
+function initMap() {
+  const geocoder = new google.maps.Geocoder();
+
+  map = new google.maps.Map(document.getElementById('map'), {
+    zoom: 12,
+  });
+
+  marker = new google.maps.Marker({
+    map: map,
+  });
+  showCurrentLocation();
+}
+
+function codeAddress() {
+  const geocoder = new google.maps.Geocoder();
+  const inputAddress = document.getElementById('address').value;
+  geocoder.geocode({ 'address': inputAddress }, function(results, status) {
+    if (status === 'OK') {
+      map.setCenter(results[0].geometry.location);
+      marker.setPosition(results[0].geometry.location);
+      latlngDis.innerHTML = `Latitude: ${results[0].geometry.location.lat()}, Longitude: ${results[0].geometry.location.lng()}`;
+      addressDis.innerHTML = results[0].formatted_address;
+    } else {
+      alert("該当する結果がありませんでした：" + status);
+    }
+  });
+}
+
+function showCurrentLocation(){
+    // ユーザーの現在地を取得してマップに設定
+    if (navigator.geolocation) {
+      navigator.geolocation.getCurrentPosition(function(position) {
+        const userLocation = {
+          lat: position.coords.latitude,
+          lng: position.coords.longitude
+        };
+        map.setCenter(userLocation);
+        marker.setPosition(userLocation);
+        latlngDis.innerHTML = `Latitude: ${userLocation.lat}, Longitude: ${userLocation.lng}`;
+      }, function() {
+        alert('位置情報の取得に失敗しました。');
+        map.setCenter({ lat: 35.6803997, lng: 139.7690174 }); // 東京の座標
+      });
+    } else {
+      // Geolocationがサポートされていないブラウザの場合
+      alert('お使いのブラウザでは地理位置情報の取得がサポートされていません。');
+      map.setCenter({ lat: 35.6803997, lng: 139.7690174 }); // 東京の座標
+    };
+}
+
+</script>
+
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GMAP_API_KEY'] %>&callback=initMap" async defer></script>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   get 'static_pages/index'
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'terms_of_use', to: 'static_pages#terms_of_use'
+  get 'spots/map'
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.


### PR DESCRIPTION
# 概要
### 【実施事項】
GoogleMapAPIの導入を行なった。
- 必要なGemのインストール
- APIkeyを取得し.envに格納
- 地図上にピンを表示させた
- その後、現在地を取得し表示させた

### 今回インストールしたGemは以下の通り
- gem 'google_places'
- gem 'gon'
- gem 'pry-rails'
- gem 'geokit-rails'
- gem 'geocoder'
- gem 'dotenv-rails'