### PR TITLE
🎨 Add:GoogleFont導入

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,9 @@
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="https://unpkg.com/@phosphor-icons/web"></script>
     <script src="//maps.google.com/maps/api/js?key=<%= ENV["GMAP_API_KEY"] %>"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@100..900&family=Zen+Maru+Gothic:wght@400;500&display=swap" rel="stylesheet">
   </head>
 
   <body>

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -2,7 +2,7 @@
   <div class="mx-auto max-w-screen-2xl px-4 md:px-8">
     <header class="mb-4 flex items-center justify-between py-4 md:py-8">
       <!-- logo - start -->
-      <a href="/" class="inline-flex items-center gap-2.5 text-xl font-bold text-secondary md:text-3xl" aria-label="logo">
+      <a href="/" class="inline-flex items-center gap-2.5 text-xl font-bold text-secondary md:text-3xl font-zenmaru font-bold" aria-label="logo">
 
         NekoSpot
       </a>
@@ -53,9 +53,9 @@
         <div class="items-center lg:flex">
             <div class="w-full lg:w-1/2">
                 <div class="lg:max-w-lg">
-                    <h1 class="text-3xl font-semibold text-neutral lg:text-4xl">猫と出会える,ふれあえる<br>スポットが見つかる</h1>
+                    <h1 class="text-3xl font-semibold font-zenmaru font-bold text-neutral lg:text-4xl">猫と出会える,ふれあえる<br>スポットが見つかる</h1>
                     
-                    <p class="mt-3 text-secondary my-6">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Porro beatae error laborum ab amet sunt recusandae? Reiciendis natus perspiciatis optio.</p>
+                    <p class="mt-3 text-secondary my-6 font-zenmaru">Lorem ipsum dolor sit amet, consectetur adipisicing elit. Porro beatae error laborum ab amet sunt recusandae? Reiciendis natus perspiciatis optio.</p>
                     <div class="hidden lg:mx-auto lg:flex lg:w-full lg:justify-center lg:gap-2.5 ">
                     <%= link_to '猫スポットを探す', '#', class: "inline-block rounded-full bg-accent px-8 py-3 text-center text-sm font-semibold text-white outline-none ring-indigo-300 transition duration-100 hover:text-neutral hover:bg-primary focus-visible:ring sm:w-1/2 text-base md:w-1/2" %>
                     <%= link_to user_line_omniauth_authorize_path, class: "inline-block sm:w-1/2", method: :post do %>
@@ -72,7 +72,7 @@
             <%= image_tag 'TOP画像2.png' %>
             </div>
             <div class="mx-auto flex w-3/4 flex-col gap-2.5 justify-center sm:flex-row lg:hidden md:hidden">
-            <%= link_to '猫スポットを探す', '#', class: "inline-block rounded-full bg-accent px-8 py-3 text-center text-sm font-semibold text-white outline-none ring-indigo-300 transition duration-100 hover:text-neutral hover:bg-primary focus-visible:ring active:bg-indigo-700 sm:w-1/2 text-base md:w-1/2" %>
+              <%= link_to '猫スポットを探す', '#', class: "inline-block rounded-full bg-accent px-8 py-3 font-sans text-center text-sm font-semibold text-white outline-none ring-indigo-300 transition duration-100 hover:text-neutral hover:bg-primary focus-visible:ring active:bg-indigo-700 sm:w-1/2 text-base md:w-1/2" %>
             </div>
             <div class="mx-auto flex w-3/4 flex-row gap-2.5 justify-center lg:hidden md:hidden">
             <%= link_to user_line_omniauth_authorize_path, class: "inline-block sm:w-1/2", method: :post do %>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,12 @@
 module.exports = {
+  theme: {
+    extend: {
+      fontFamily: {
+        'zenmaru': ['Zen Maru Gothic', 'sans-serif'],
+        'sans': ['Noto Sans JS', 'sans-serif'],
+      }
+    },
+  },
   content: [
     './app/views/**/*.html.erb',
     './app/helpers/**/*.rb',


### PR DESCRIPTION
# 概要
### GoogleFont導入
 - Zen Maru Gothic(本当は筑紫丸ゴシックを使用したかったが有料フォントであったためよく似たこちらのフォントを採用)
 - Noto Sans Japanese