### PR TITLE
🐛 Fix:デプロイ時にyarn build:customが実行されるように修正

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,6 +6,7 @@ rm -f /myapp/tmp/pids/server.pid
 
 if [ "${RAILS_ENV}" = "production" ]
 then
+    yarn build:custom
     bundle exec rails assets:precompile
 fi
 


### PR DESCRIPTION
# 概要
## 本番環境での`ActionView::Template::Error (The asset "gmap.js" is not present in the asset pipeline.`エラーの解消
- `entrypoint.sh`にデプロイ時に`yarn build:custom`が実行されるよう修正