### PR TITLE
🐛 Fix:JavaScriptの読み込みを修正

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,2 @@
-web: env RUBY_DEBUG_OPEN=true bin/rails server
 js: yarn build --watch
 css: yarn build:css --watch

--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -1,5 +1,3 @@
 // Entry point for the build script in your package.json
 import "@hotwired/turbo-rails"
 import "./controllers"
-import './show_map';
-import './gmap';

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -35,7 +35,7 @@
 
   <div class="flex flex-col items-center justify-center md:my-8 md:bottom-0 bottom-20 w-full relative">
     <% @spots.each do |spot| %>
-    <%= link_to spot_path(spot), class: "w-11/12 rounded-xl" do %>
+    <%= link_to spot_path(spot), data: { turbo: false }, class: "w-11/12 rounded-xl" do %>
       <div id="infoCard-<%= spot.id %>" class="hidden bg-white border rounded-xl shadow-sm flex mx-auto w-11/12 md:w-full absolute md:relative bottom-0 inset-x-0 z-10 md:mb-50 hover:shadow-lg group">
       <!-- ×ボタン -->
       <button onclick="hideInfoCard(event, <%= spot.id %>)" class="absolute top-1 right-2 text-secondary focus:outline-none z-20 md:hidden">


### PR DESCRIPTION
# 概要
## エラー修正
- `application.js`で`show_map`と`gmap`の読み込みを削除
- infoCardのリンクに`data: { turbo: false }`を記述