### PR TITLE
42 スポット保存機能 絞り込み機能カテゴリー

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -52,6 +52,11 @@ class SpotsController < ApplicationController
   def bookmarks
     @q = current_user.spot_bookmarks.joins(:spot).ransack(params[:q])
     @bookmark_spots = @q.result(distinct: true).includes(:spot).order(created_at: :desc)
+
+    bookmarked_spots = current_user.spot_bookmarks.joins(:spot).map(&:spot)
+    @categories = bookmarked_spots.map(&:category).uniq
+    prefecture_ids = bookmarked_spots.map(&:prefecture_id).uniq
+    @prefectures = Prefecture.find(prefecture_ids)
   end
 
   def show

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -7,4 +7,20 @@ module ApplicationHelper
       else "p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400"
       end
     end
+
+    def formatted_address(address)
+      # 正規表現で都道府県、市区町村、以降の住所を抽出
+      match_data = address.match(/(?<prefecture>東京都|北海道|(?:京都|大阪)府|.{2,3}県)(?<city>[^区町村]+[市町村])?(?<ward>[^区町村]*区)?/)
+      return address unless match_data # 住所が正しくない場合はそのまま返す
+  
+      prefecture = match_data[:prefecture]
+      city = match_data[:city]
+      ward = match_data[:ward]
+  
+      formatted_address = "#{prefecture}"
+      formatted_address += "#{city}" if city.present?
+      formatted_address += "#{ward}" if ward.present?
+  
+      formatted_address
+    end
   end

--- a/app/views/spots/_bookmark_buttons.html.erb
+++ b/app/views/spots/_bookmark_buttons.html.erb
@@ -1,7 +1,11 @@
-<div class='mx-auto'>
-    <% if current_user.bookmark?(spot) %>
-        <%= render 'unbookmark', { spot: spot } %>
-    <% else %>
-        <%= render 'bookmark', { spot: spot } %>
-    <% end %>
-</div>
+<% if user_signed_in? %>
+    <div class='mx-auto'>
+        <% if current_user.bookmark?(spot) %>
+            <%= render 'unbookmark', { spot: spot } %>
+        <% else %>
+            <%= render 'bookmark', { spot: spot } %>
+        <% end %>
+    </div>
+<% else %>
+    <i class="ph ph-bookmark-simple fa-lg text-secondary"></i>
+<% end %>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,18 +1,19 @@
-<div class="bg-white shadow-sm flex md:flex-col mx-auto w-full border rounded-xl md:mb-50 hover:shadow-lg group my-3">
+<div class="bg-white shadow-sm flex md:flex-col mx-auto w-full h-full border rounded-xl md:mb-50 hover:shadow-lg group my-3">
     <div class="flex-shrink-0 rounded-l-xl md:rounded-t-xl md:rounded-b-none relative overflow-hidden h-32 w-1/3 md:h-42 md:w-full md:rounded-t-xl">
         <%= link_to spot_path(spot) do %>
         <img src="https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=<%= spot.spot_images.first.image %>&key=<%= ENV['GMAP_API_KEY'] %>" class="w-full h-full absolute rounded-l-xl md:rounded-t-xl md:rounded-b-none top-0 left-0 md:left-none object-cover transition-transform duration-200 ease-in-out group-hover:scale-110 group-hover:rounded-xl" alt="Image Description">
         <% end %>
     </div>
-    <div class="flex flex-wrap w-full">
-        <div class="p-4 flex flex-col h-full sm:p-7 w-full md:relative">
+    <div class="flex flex-wrap w-full md:h-full">
+        <div class="p-4 md:p-2.5 flex flex-col h-full sm:p-7 w-full md:relative">
             <div class="hidden md:block bg-accent absolute top-0 -mt-3 flex items-center px-3 py-1.5 leading-none w-auto inline-block rounded-full text-xs font-medium uppercase text-white inline-block">
                 <span><%= spot.category.name %></span>
             </div>
             <%= link_to spot_path(spot) do %>
-                <h2 class="font-bold text-neutral font-zenmaru overflow-hidden w-full whitespace-nowrap text-overflow-ellipsis"><%= spot.name %></h2>
+                <h2 class="font-bold text-neutral font-zenmaru md:mt-2 md:px-2 overflow-hidden w-full whitespace-nowrap text-overflow-ellipsis"><%= spot.name %></h2>
             <% end %>
-            <div class="justify-between flex md:space-x-4 space-x-2 mt-2">
+            <p class="md:px-2 text-xs text-secondary py-1 dark:text-neutral-500"><%= formatted_address(spot.address) %></p>
+            <div class="justify-between flex items-end h-full md:space-x-4 space-x-2">
                 <div class="flex space-x-2">
                     <div class="inline-flex">
                         <p class="md:hidden text-xs text-white py-1 px-2 rounded-full bg-accent dark:text-neutral-500"><%= spot.category.name %></p>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -10,9 +10,9 @@
                 <span><%= spot.category.name %></span>
             </div>
             <%= link_to spot_path(spot) do %>
-                <h2 class="font-bold text-neutral font-zenmaru md:mt-2 md:px-2 overflow-hidden w-full whitespace-nowrap text-overflow-ellipsis"><%= spot.name %></h2>
+                <h2 class="font-bold text-neutral font-zenmaru md:mt-2 md:px-1.5 overflow-hidden w-full whitespace-nowrap text-overflow-ellipsis"><%= spot.name %></h2>
             <% end %>
-            <p class="md:px-2 text-xs text-secondary py-1 dark:text-neutral-500"><%= formatted_address(spot.address) %></p>
+            <p class="md:px-1.5 text-xs text-secondary py-1 dark:text-neutral-500"><%= formatted_address(spot.address) %></p>
             <div class="justify-between flex items-end h-full md:space-x-4 space-x-2">
                 <div class="flex space-x-2">
                     <div class="inline-flex">

--- a/app/views/spots/bookmarks.html.erb
+++ b/app/views/spots/bookmarks.html.erb
@@ -22,11 +22,11 @@
                         <%= f.submit '検索', class: 'text-white absolute end-2 py-2 bottom-2.5 bg-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-primary font-medium rounded-full text-sm px-4 py-0.5' %>
                     </div>
                 <% end %>
-                        <% if @bookmark_spots.present? %>
+                    <% if @bookmark_spots.present? %>
                         <div class="md:grid md:grid-cols-3 md:gap-4">
-                        <% @bookmark_spots.each do |bookmark_spot| %>
-                            <%= render 'spots/spot', spot: bookmark_spot.spot %>
-                        <% end %>
+                            <% @bookmark_spots.each do |bookmark_spot| %>
+                                <%= render 'spots/spot', spot: bookmark_spot.spot %>
+                            <% end %>
                         </div>
                     <% else %>
                         <h2 class="text-xl font-zenmaru font-bold text-neutral">お気に入り一覧</h2>

--- a/app/views/spots/bookmarks.html.erb
+++ b/app/views/spots/bookmarks.html.erb
@@ -21,6 +21,16 @@
                         <%= f.search_field :spot_name_or_spot_address_cont, class: 'block w-full p-4 ps-10 text-sm text-secondary border rounded-full bg-white focus:ring-secondary focus:border-secondary dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
                         <%= f.submit '検索', class: 'text-white absolute end-2 py-2 bottom-2.5 bg-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-primary font-medium rounded-full text-sm px-4 py-0.5' %>
                     </div>
+                    <div class="nav-down">
+                        <div class='label-select'>
+                            <%= f.label :spot_category_id_eq, 'カテゴリー', class: 'label' %>
+                            <%= f.collection_select :spot_category_id_eq, @categories, :id, :name,  include_blank: '指定なし', class: 'search-select' %>
+                        </div>
+                        <div class='label-select'>
+                            <%= f.label :spot_prefecture_id_eq, '都道府県', class: 'label' %>
+                            <%= f.collection_select :spot_prefecture_id_eq, @prefectures, :id, :name,  include_blank: '指定なし', class: 'search-select' %>
+                        </div>
+                    </div>
                 <% end %>
                     <% if @bookmark_spots.present? %>
                         <div class="md:grid md:grid-cols-3 md:gap-4">

--- a/app/views/spots/bookmarks.html.erb
+++ b/app/views/spots/bookmarks.html.erb
@@ -12,24 +12,24 @@
 
             <div id="details-tab" class="hidden bg-white py-4 px-4 w-full border-l border-b border-r rounded-b-lg rounded-r-lg" data-tabs-target="panel">
                 <div class="w-full mx-auto pb-8">
-                <%= search_form_for @q, url: bookmarks_spots_path, html: { id: "searchForm", class: "max-w-md mx-auto w-11/12 py-4" }  do |f| %>
-                    <label for="" class="mb-2 text-sm font-medium text-secondary sr-only dark:text-white">検索</label>
-                    <div class="relative">
+                <%= search_form_for @q, url: bookmarks_spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto py-8" }  do |f| %>
+                    <label for="" class="mb-2 text-sm font-medium h-full text-secondary sr-only dark:text-white">検索</label>
+                    <div class="nav-down text-secondary flex items-center h-12">
+                        <div class='label-select border rounded-l-xl h-full text-sm'>
+                            <%= f.label :spot_category_id_eq, 'カテゴリ', class: 'label text-xs' %>
+                            <%= f.collection_select :spot_category_id_eq, @categories, :id, :name,  include_blank: '指定なし', class: 'search-select text-sm' %>
+                        </div>
+                        <div class='label-select border h-full text-sm'>
+                            <%= f.label :spot_prefecture_id_eq, '都道府県', class: 'label text-xs' %>
+                            <%= f.collection_select :spot_prefecture_id_eq, @prefectures, :id, :name,  include_blank: '指定なし', class: 'search-select text-sm' %>
+                        </div>
+                        <div class="relative w-full h-full text-xs">
                         <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
                         <i class="ph ph-magnifying-glass text-secondary"></i>
                         </div>
-                        <%= f.search_field :spot_name_or_spot_address_cont, class: 'block w-full p-4 ps-10 text-sm text-secondary border rounded-full bg-white focus:ring-secondary focus:border-secondary dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
-                        <%= f.submit '検索', class: 'text-white absolute end-2 py-2 bottom-2.5 bg-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-primary font-medium rounded-full text-sm px-4 py-0.5' %>
+                        <%= f.search_field :spot_name_or_spot_address_cont, class: 'block w-full p-4 ps-10 h-full text-sm text-secondary border rounded-e-lg bg-white focus:ring-secondary focus:border-secondary dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
+                        <%= f.submit class: 'absolute top-0 end-0 p-2.5 text-sm font-medium h-full text-white bg-accent rounded-e-lg border border-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-secondary dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800' %>
                     </div>
-                    <div class="nav-down">
-                        <div class='label-select'>
-                            <%= f.label :spot_category_id_eq, 'カテゴリー', class: 'label' %>
-                            <%= f.collection_select :spot_category_id_eq, @categories, :id, :name,  include_blank: '指定なし', class: 'search-select' %>
-                        </div>
-                        <div class='label-select'>
-                            <%= f.label :spot_prefecture_id_eq, '都道府県', class: 'label' %>
-                            <%= f.collection_select :spot_prefecture_id_eq, @prefectures, :id, :name,  include_blank: '指定なし', class: 'search-select' %>
-                        </div>
                     </div>
                 <% end %>
                     <% if @bookmark_spots.present? %>


### PR DESCRIPTION
## 概要
お気に入り内でエリア / カテゴリ検索を実装
### 実装ページ
[![Image from Gyazo](https://i.gyazo.com/a777784132327c2c9640a825d3d756ad.gif)](https://gyazo.com/a777784132327c2c9640a825d3d756ad)
### 内容
- [x] ransackでカテゴリ検索
- [x] ransackでエリア検索
- [x] selectタブ内にはお気に入りに登録したスポットの都道府県やカテゴリのみ表示されるように実装
- [x] Cardに住所表示(ヘルパーメソッド`formatted_address`を定義し「兵庫県神戸市中央区」のように表示されるようにした)
- [x] レイアウト調整