### PR TITLE
【Fix】口コミ件数と平均を投稿編集削除後に非同期で更新されるようにする

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -27,6 +27,8 @@ class ReviewsController < ApplicationController
       flash.now[:success] = "口コミを更新しました"
       render turbo_stream: [
         turbo_stream.replace(@review),
+        turbo_stream.replace("average_rating", partial: "spots/average_rating", locals: { spot: @spot }),
+        turbo_stream.replace("reviews_count", partial: "spots/reviews_count", locals: { spot: @spot }),
         turbo_stream.update("flash", partial: "layouts/flash_messages")
       ]
     else
@@ -36,7 +38,7 @@ class ReviewsController < ApplicationController
 
   def destroy
     @review.destroy!
-    flash.now[:success] = "口コミを更新しました"
+    flash.now[:success] = "口コミを削除しました"
     render turbo_stream: [
       turbo_stream.remove(@review),
       turbo_stream.update("flash", partial: "layouts/flash_messages")

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -1,7 +1,8 @@
 class ReviewsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :create, :edit, :update, :destroy]
-  before_action :set_spot, only: [:new, :create, :edit, :update]
+  before_action :set_spot, only: [:new, :create, :edit, :update, :destroy]
   before_action :set_review, only: [:edit, :update, :destroy]
+  before_action :reviews_data, only: [:create, :update, :destroy]
 
   def new
     @review = Review.new
@@ -13,6 +14,9 @@ class ReviewsController < ApplicationController
       flash.now[:success] = "口コミを投稿しました"
       render turbo_stream: [
         turbo_stream.prepend("reviews", @review),
+        turbo_stream.replace("average_rating", partial: "spots/average_rating"),
+        turbo_stream.replace("reviews_count", partial: "spots/reviews_count"),
+        turbo_stream.replace("review_tab", partial: "spots/review_tab"),
         turbo_stream.update("flash", partial: "layouts/flash_messages")
       ]
     else
@@ -27,8 +31,7 @@ class ReviewsController < ApplicationController
       flash.now[:success] = "口コミを更新しました"
       render turbo_stream: [
         turbo_stream.replace(@review),
-        turbo_stream.replace("average_rating", partial: "spots/average_rating", locals: { spot: @spot }),
-        turbo_stream.replace("reviews_count", partial: "spots/reviews_count", locals: { spot: @spot }),
+        turbo_stream.replace("average_rating", partial: "spots/average_rating"),
         turbo_stream.update("flash", partial: "layouts/flash_messages")
       ]
     else
@@ -41,6 +44,9 @@ class ReviewsController < ApplicationController
     flash.now[:success] = "口コミを削除しました"
     render turbo_stream: [
       turbo_stream.remove(@review),
+      turbo_stream.replace("average_rating", partial: "spots/average_rating"),
+      turbo_stream.replace("reviews_count", partial: "spots/reviews_count"),
+      turbo_stream.replace("review_tab", partial: "spots/review_tab"),
       turbo_stream.update("flash", partial: "layouts/flash_messages")
     ], status: :see_other
   end
@@ -57,5 +63,11 @@ class ReviewsController < ApplicationController
 
   def set_review
     @review = Review.find(params[:id])
+  end
+
+  def reviews_data
+    @reviews = @spot.reviews.includes(:user).order(created_at: :desc).page(params[:page]).per(10)
+    @average_rating = @spot.reviews.average(:rating).to_f
+    @all_reviews_count = @spot.reviews.count
   end
 end

--- a/app/controllers/spot_bookmarks_controller.rb
+++ b/app/controllers/spot_bookmarks_controller.rb
@@ -4,10 +4,12 @@ class SpotBookmarksController < ApplicationController
     def create
         @spot = Spot.find(params[:spot_id])
         current_user.bookmark(@spot)
+        flash.now[:success] = "スポットをお気に入りに追加しました"
     end
 
     def destroy
         @spot = current_user.spot_bookmarks.find(params[:id]).spot
         current_user.unbookmark(@spot)
+        flash.now[:success] = "スポットをお気に入りから削除しました"
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,11 +1,15 @@
 module ApplicationHelper
     def flash_background_color(type)
       case type.to_sym
-      when :notice then "p-4 mb-4 text-sm text-blue-800 rounded-lg bg-blue-50 dark:bg-gray-800 dark:text-blue-400"
-      when :alert  then "p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400"
-      when :success  then "p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50 dark:bg-gray-800 dark:text-green-400"
-      else "p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400"
+      when :notice then "md:mt-16 p-4 text-sm text-blue-800 rounded-lg bg-blue-50 dark:bg-gray-800 dark:text-blue-400"
+      when :alert  then "md:mt-16 p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400"
+      when :success  then "md:mt-16 p-4 text-sm text-green-800 rounded-lg bg-green-50 dark:bg-gray-800 dark:text-green-400"
+      else "md:mt-16 p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400"
       end
+    end
+
+    def turbo_stream_flash
+      turbo_stream.update "flash", partial: "layouts/flash_messages"
     end
 
     def formatted_address(address)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,9 @@
       <%= render "shared/before_login_header" %>
     <% end %>
   <% end %>
+  <div id="flash">
     <%= render 'layouts/flash_messages', flash: flash %>
+  </div>
     <%= yield %>
     <%= render "shared/footer" %>
   </body>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -1,4 +1,4 @@
-<%= turbo_frame_tag review do %>
+<%= turbo_frame_tag dom_id(review) do %>
     <div class="flex flex-col gap-3 px-4 py-6 md:p-6 space-y-2">
     <div class="flex w-full justify-between">
         <div class="flex items-center">
@@ -11,7 +11,7 @@
             </div>
         </div>
         <div class="flex space-x-2 items-center">
-        <% if review.user == @user %>
+        <% if review.user == current_user %>
             <%= render 'reviews/crud_menus', review: review %>
         <% end %>
         </div>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -31,17 +31,17 @@
   <% else %>
 <div class="fixed bottom-0 left-0 z-50 w-full h-16 bg-primary border-t border-secondary md:hidden">
     <div class="grid h-full max-w-lg grid-cols-3 mx-auto font-medium">
-        <button type="button" class="inline-flex flex-col items-center justify-center px-5 hover:bg-gray-50 group">
+        <button type="button" class="inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group">
         <i class="ph-bold ph-magnifying-glass fa-lg w-5 h-5 mb-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
-            <span class="text-xs text-secondary dark:text-gray-400 group-hover:text-neutral">検索</span>
+            <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">検索</span>
         </button>
-        <button type="button" class="inline-flex flex-col items-center justify-center px-5 hover:bg-gray-50 group">
+        <button type="button" class="inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group">
         <i class="ph-bold ph-list-dashes fa-lg w-5 h-5 mb-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
-            <span class="text-xs text-secondary dark:text-gray-400 group-hover:text-neutral">一覧</span>
+            <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">一覧</span>
         </button>
-        <button type="button" class="inline-flex flex-col items-center justify-center px-5 hover:bg-gray-50 group" onclick="my_modal_4.showModal()" >
+        <button type="button" class="inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" onclick="my_modal_4.showModal()" >
         <i class="ph-bold ph-sign-in fa-lg w-5 h-5 mb-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
-            <span class="text-xs text-secondary dark:text-gray-400 group-hover:text-neutral">ログイン</span>
+            <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">ログイン</span>
         </button>
         <dialog id="my_modal_4" class="modal">
   <div class="modal-box">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -32,25 +32,25 @@
 <% else %>
 <div class="fixed bottom-0 left-0 z-50 w-full h-16 bg-primary border-t border-secondary md:hidden">
     <div class="grid h-full max-w-lg grid-cols-5 mx-auto font-medium">
-        <%= link_to spots_path, data: { "turbolinks" => false }, class: "inline-flex flex-col items-center justify-center px-5 hover:bg-gray-50 group" do %>
+        <%= link_to spots_path, data: { "turbolinks" => false }, class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
             <i class="ph-bold ph-magnifying-glass w-5 h-5 mb-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
-            <span class="text-xs text-secondary dark:text-gray-400 group-hover:text-neutral">検索</span>
+            <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">検索</span>
         <% end %>
-        <%= link_to "#", class: "inline-flex flex-col items-center justify-center px-5 hover:bg-gray-50 group" do %>
+        <%= link_to "#", class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
             <i class="ph-bold ph-list-dashes w-5 h-5 mb-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
-            <span class="text-xs text-secondary dark:text-gray-400 group-hover:text-neutral">一覧</span>
+            <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">一覧</span>
         <% end %>
-        <button type="button" class="inline-flex flex-col items-center justify-center px-4 hover:bg-gray-50 group">
+        <button type="button" class="inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group">
         <i class="ph-bold ph-plus w-5 h-5 mb-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
-            <span class="text-xs text-secondary group-hover:text-neutral">投稿する</span>
+            <span class="text-[9px] text-secondary group-hover:text-neutral">投稿する</span>
         </button>
-        <%= link_to bookmarks_spots_path, method: :get, class: "inline-flex flex-col items-center justify-center px-5 hover:bg-gray-50 group" do %>
+        <%= link_to bookmarks_spots_path, method: :get, class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
             <i class="ph-fill ph-heart w-5 h-5 mb-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
-            <span class="text-xs text-secondary dark:text-gray-400 group-hover:text-neutral">お気に入り</span>
+            <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">お気に入り</span>
         <% end %>
-        <%= link_to users_show_path(current_user), method: :get, class: "inline-flex flex-col items-center justify-center px-5 hover:bg-gray-50 group" do %>
+        <%= link_to users_show_path(current_user), method: :get, class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
             <i class="ph ph-user-circle w-5 h-5 mb-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
-            <span class="text-xs text-secondary dark:text-gray-400 group-hover:text-neutral">Myページ</span>
+            <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">Myページ</span>
         <% end %>
     </div>
 </div>

--- a/app/views/spot_bookmarks/create.turbo_stream.erb
+++ b/app/views/spot_bookmarks/create.turbo_stream.erb
@@ -1,3 +1,5 @@
 <%= turbo_stream.replace "bookmark-button-for-spot-#{@spot.id}" do %>
     <%= render 'spots/unbookmark', spot: @spot %>
 <% end %>
+
+<%= turbo_stream_flash %>

--- a/app/views/spot_bookmarks/destroy.turbo_stream.erb
+++ b/app/views/spot_bookmarks/destroy.turbo_stream.erb
@@ -1,3 +1,5 @@
 <%= turbo_stream.replace "unbookmark-button-for-spot-#{@spot.id}" do %>
     <%= render 'spots/bookmark', spot: @spot %>
 <% end %>
+
+<%= turbo_stream_flash %>

--- a/app/views/spots/_average_rating.html.erb
+++ b/app/views/spots/_average_rating.html.erb
@@ -1,9 +1,8 @@
-                <div class="rating rating-md rating-half">
-                <input type="radio" name="rating-10" class="rating-hidden" />
-              
-                <% (1..5).each do |i| %>
-                  <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-1" <%= 'checked' if @average_rating >= (i - 0.5) && @average_rating < i %> />
-                  <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-2" <%= 'checked' if @average_rating >= i %> />
-                <% end %>
-                <span class="text-sm font-semibold text-secondary"><%= @average_rating.round(2) %> (<%= @all_reviews_count %>件)</span>
-              </div>
+<div class="rating rating-md rating-half" id="average_rating">
+<input type="radio" name="rating-10" class="rating-hidden" />
+    <% (1..5).each do |i| %>
+        <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-1" <%= 'checked' if @average_rating >= (i - 0.5) && @average_rating < i %> />
+        <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-2" <%= 'checked' if @average_rating >= i %> />
+    <% end %>
+<span class="text-sm font-semibold text-secondary" ><%= @average_rating.round(2) %></span>
+</div>

--- a/app/views/spots/_average_rating.html.erb
+++ b/app/views/spots/_average_rating.html.erb
@@ -1,0 +1,9 @@
+                <div class="rating rating-md rating-half">
+                <input type="radio" name="rating-10" class="rating-hidden" />
+              
+                <% (1..5).each do |i| %>
+                  <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-1" <%= 'checked' if @average_rating >= (i - 0.5) && @average_rating < i %> />
+                  <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-2" <%= 'checked' if @average_rating >= i %> />
+                <% end %>
+                <span class="text-sm font-semibold text-secondary"><%= @average_rating.round(2) %> (<%= @all_reviews_count %>件)</span>
+              </div>

--- a/app/views/spots/_review_tab.html.erb
+++ b/app/views/spots/_review_tab.html.erb
@@ -1,0 +1,1 @@
+<a class="bg-white inline-block py-2 px-4 rounded-t-lg text-secondary hover:text-neutral font-semibold no-underline rounded-t-lg" id="review_tab" href="#">口コミ(<%= @reviews.present? ? @all_reviews_count : 0 %>件)</a>

--- a/app/views/spots/_reviews_count.html.erb
+++ b/app/views/spots/_reviews_count.html.erb
@@ -1,0 +1,1 @@
+<span class="text-sm font-semibold text-secondary" id="reviews_count"> (<%= @all_reviews_count %>件)</span>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,4 +1,7 @@
-<div class="md:flex md:mt-16">
+<div class="hidden md:block md:ml-64 md:mt-3">
+  <%= render 'layouts/flash_messages', flash: flash %>
+</div>
+<div class="md:flex <%= 'md:mt-16' unless flash.any? %>">
   <div data-controller="sidebar">
     <%= render "spots/sidebar" %>
   </div>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,5 +1,5 @@
-<div class="bg-primary relative md:pb-16 md:mb-0 mb-20">
-  <div class="relative overflow-hidden md:mt-16" data-controller="carousel">
+<div class="bg-primary relative md:pb-16 md:mb-0 mb-20 <%= 'md:mt-16' unless flash.any? %>">
+  <div class="relative overflow-hidden" data-controller="carousel">
     <div class="whitespace-nowrap transition duration-700 ease-in-out" data-carousel-target="container">
       <% @spot.spot_images.each_with_index do |image, index| %>
         <div data-carousel-target="item" class="inline-block w-full">
@@ -85,7 +85,6 @@
         <% if @reviews.present? %>
           <div id="reviews">
           <div class="grid sm:grid-cols-2 lg:grid-cols-3 lg:gap-12">
-          <!-- overview - start -->
           <div>
           
             <div class="md:mx-8 my-3 rounded-lg border p-4 mx-auto justify-center items-center">
@@ -93,17 +92,9 @@
     
               <div class="mb-0.5 flex items-center gap-2">
                 <!-- stars - start -->
-                <div class="rating rating-md rating-half">
-                <input type="radio" name="rating-10" class="rating-hidden" />
-              
-                <% (1..5).each do |i| %>
-                  <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-1" <%= 'checked' if @average_rating >= (i - 0.5) && @average_rating < i %> />
-                  <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-2" <%= 'checked' if @average_rating >= i %> />
-                <% end %>
-                <span class="text-sm font-semibold text-secondary"><%= @average_rating.round(2) %> (<%= @all_reviews_count %>件)</span>
+                <%= render 'spots/average_rating', spot: @spot %>
               </div>
-                </div>
-              </div>
+            </div>
           </div>
           <div class="lg:col-span-2 md:mr-8">
             <%= turbo_frame_tag 'review_modal' do %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -20,7 +20,7 @@
           <a class="bg-white inline-block py-2 px-4 rounded-t-lg text-secondary hover:text-neutral font-semibold no-underline rounded-t-lg" href="#">詳細情報</a>
         </li>
         <li class="mr-1 w-1/2 bg-white rounded-t-lg text-center" data-tabs-target="tab" data-action="click->tabs#change">
-          <a class="bg-white inline-block py-2 px-4 rounded-t-lg text-secondary hover:text-neutral font-semibold no-underline rounded-t-lg" href="#">口コミ(<%= @reviews.present? ? @all_reviews_count : 0 %>件)</a>
+          <a class="bg-white inline-block py-2 px-4 rounded-t-lg text-secondary hover:text-neutral font-semibold no-underline rounded-t-lg" id="review_tab" href="#">口コミ(<%= @reviews.present? ? @all_reviews_count : 0 %>件)</a>
         </li>
       </ul>
 
@@ -83,23 +83,30 @@
 
       <div id="reviews-tab" class="hidden bg-white p-4 w-full border-l border-b border-r rounded-l-lg rounded-b-lg" data-tabs-target="panel">
         <% if @reviews.present? %>
-          <div id="reviews">
-          <div class="grid sm:grid-cols-2 lg:grid-cols-3 lg:gap-12">
-          <div>
-          
-            <div class="md:mx-8 my-3 rounded-lg border p-4 mx-auto justify-center items-center">
-              <h2 class="pl-3 mb-3 text-xl font-zenmaru font-bold text-neutral">スポット平均</h2>
-    
-              <div class="mb-0.5 flex items-center gap-2">
-                <!-- stars - start -->
-                <%= render 'spots/average_rating', spot: @spot %>
+            <div class="grid sm:grid-cols-2 lg:grid-cols-3 lg:gap-12">
+              <div>
+                <div class="md:mx-8 my-3 rounded-lg border p-4 mx-auto justify-center items-center">
+                  <h2 class="pl-3 mb-3 text-xl font-zenmaru font-bold text-neutral">スポット平均</h2>
+        
+                  <div class="mb-0.5 flex items-center gap-2">
+                    <!-- stars - start -->
+                    <div class="rating rating-md rating-half" id="average_rating">
+                    <input type="radio" name="rating-10" class="rating-hidden" />
+                          <% (1..5).each do |i| %>
+                              <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-1" <%= 'checked' if @average_rating >= (i - 0.5) && @average_rating < i %> />
+                              <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-2" <%= 'checked' if @average_rating >= i %> />
+                          <% end %>
+                      <span class="text-sm font-semibold text-secondary"><%= @average_rating.round(2) %></span>
+                    </div>
+                    <span class="text-sm font-semibold text-secondary" id="reviews_count"> (<%= @all_reviews_count %>件)</span>
+                  </div>
+                </div>
               </div>
-            </div>
-          </div>
-          <div class="lg:col-span-2 md:mr-8">
+              <div class="lg:col-span-2 md:mr-8">
             <%= turbo_frame_tag 'review_modal' do %>
               <h2 class="my-3 text-xl font-zenmaru font-bold text-neutral border-bottom">口コミ一覧</h2>
               <div class="grid divide-y">
+              <div id="reviews">
               <%= render @reviews %>
               </div>
               <%= paginate @reviews %>


### PR DESCRIPTION
# 概要
以下の修正を行った。
- TOPページ以外でフラッシュメッセージが表示されなかったため修正
- 口コミ投稿編集削除後に口コミ件数と平均評価を非同期で更新されるようにする
- スマホ画面用メニューバーの文字のレイアウト崩れ

## 実装画面
### フラッシュメッセージの表示
[![Image from Gyazo](https://i.gyazo.com/a67b59ee0837e80ddb19f1a764777e75.gif)](https://gyazo.com/a67b59ee0837e80ddb19f1a764777e75)

### 口コミ件数と平均評価を非同期で更新
[![Image from Gyazo](https://i.gyazo.com/155e198380a62d747452bb6e56df1dbb.gif)](https://gyazo.com/155e198380a62d747452bb6e56df1dbb)

### メニューバー(スマホ画面)の文字の大きさを修正
[![Image from Gyazo](https://i.gyazo.com/9415b836e41c1a62ad40c51dd167fa1a.png)](https://gyazo.com/9415b836e41c1a62ad40c51dd167fa1a)

## 内容
- [x] `turbo_stream_flash`ビューヘルパー作成
- [x] 口コミ件数と平均評価のパーシャルを作成し更新時に`replace`されるようにする
- [x] 口コミ編集・ 削除ボタンがリロードしないと表示されない → 表示の条件分岐を`@user`から`current_user`にすることで解決
- [x] スマホ画面用メニューバーの文字サイズを `text-[9px]`へ変更