### PR TITLE
129 現在地の取得中にローディングスピナーが表示されるようにする

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -58,12 +58,12 @@ class ReviewsController < ApplicationController
   def search
     query = params[:q]
     if query.present?
-      @reviews = Review.ransack(spot_name_or_spot_address_or_body_cont).result
+      @reviews = Review.ransack(spot_name_or_spot_address_or_body_cont: query).result
       @search_by_spot_name = Review.ransack(spot_name_cont: query).result.exists?
       @search_by_spot_address = Review.ransack(spot_address_cont: query).result.exists?
       @search_by_body = Review.ransack(body_cont: query).result.exists?
     else
-      @rewiews = Review.none
+      @reviews = Review.none
       @search_by_spot_name = false
       @search_by_spot_address = false
       @search_by_body = false

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -55,6 +55,26 @@ class ReviewsController < ApplicationController
     ], status: :see_other
   end
 
+  def search
+    query = params[:q]
+    if query.present?
+      @reviews = Review.ransack(spot_name_or_spot_address_or_body_cont).result
+      @search_by_spot_name = Review.ransack(spot_name_cont: query).result.exists?
+      @search_by_spot_address = Review.ransack(spot_address_cont: query).result.exists?
+      @search_by_body = Review.ransack(body_cont: query).result.exists?
+    else
+      @rewiews = Review.none
+      @search_by_spot_name = false
+      @search_by_spot_address = false
+      @search_by_body = false
+    end
+
+    respond_to do |format|
+      format.html # For normal HTML requests
+      format.json # For AJAX requests
+    end
+  end
+
   private
 
   def review_params

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -78,6 +78,24 @@ class SpotsController < ApplicationController
     @average_rating = @spot.reviews.average(:rating).to_f
   end
 
+  def search
+    query = params[:q]
+    if query.present?
+      @spots = Spot.ransack(name_or_address_cont: query).result
+      @search_by_name = Spot.ransack(name_cont: query).result.exists?
+      @search_by_address = Spot.ransack(address_cont: query).result.exists?
+    else
+      @spots = Spot.none
+      @search_by_name = false
+      @search_by_address = false
+    end
+
+    respond_to do |format|
+      format.html # For normal HTML requests
+      format.json # For AJAX requests
+    end
+  end
+
   def set_map_data
     @q = Spot.ransack(params[:q])  # フリーワード検索のパラメータを受け取る
     @spots = @q.result(distinct: true).includes(:spot_images, :category)

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -8,6 +8,9 @@ application.register('tabs', Tabs)
 import { Modal } from "tailwindcss-stimulus-components"
 application.register('modal', Modal)
 
+import { Autocomplete } from 'stimulus-autocomplete'
+application.register('autocomplete', Autocomplete)
+
 // Configure Stimulus development experience
 application.debug = true
 window.Stimulus   = application

--- a/app/views/reviews/search.html.erb
+++ b/app/views/reviews/search.html.erb
@@ -1,0 +1,18 @@
+<% if @search_by_spot_name %>
+  <% @reviews.each do |review| %>
+    <li class="bg-white flex items-center gap-x-3.5 py-2 px-3 text-sm text-secondary capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.name %>">
+      <%= review.spot.name %>
+    </li>
+  <% end %>
+<% elsif @search_by_spot_address %>
+  <% @reviews.each do |review| %>
+    <li class="bg-white flex items-center gap-x-3.5 py-2 px-3 text-sm text-secondary capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.address %>">
+      <%= review.spot.address %>
+    </li>
+<% elsif @search_by_body %>
+  <% @reviews.each do |review| %>
+    <li class="bg-white flex items-center gap-x-3.5 py-2 px-3 text-sm text-secondary capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.address %>">
+      <%= review.body %>
+    </li>
+  <% end %>
+<% end %>

--- a/app/views/reviews/search.html.erb
+++ b/app/views/reviews/search.html.erb
@@ -1,17 +1,18 @@
 <% if @search_by_spot_name %>
   <% @reviews.each do |review| %>
-    <li class="bg-white flex items-center gap-x-3.5 py-2 px-3 text-sm text-secondary capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.name %>">
+    <li class="bg-white flex items-center gap-x-3.5 py-2 px-3 text-sm text-secondary capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= review.id %>" data-autocomplete-label="<%= review.spot.name %>">
       <%= review.spot.name %>
     </li>
   <% end %>
 <% elsif @search_by_spot_address %>
   <% @reviews.each do |review| %>
-    <li class="bg-white flex items-center gap-x-3.5 py-2 px-3 text-sm text-secondary capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.address %>">
+    <li class="bg-white flex items-center gap-x-3.5 py-2 px-3 text-sm text-secondary capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= review.id %>" data-autocomplete-label="<%= review.spot.address %>">
       <%= review.spot.address %>
     </li>
+  <% end %>
 <% elsif @search_by_body %>
   <% @reviews.each do |review| %>
-    <li class="bg-white flex items-center gap-x-3.5 py-2 px-3 text-sm text-secondary capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.address %>">
+    <li class="bg-white flex items-center gap-x-3.5 py-2 px-3 text-sm text-secondary capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= review.id %>" data-autocomplete-label="<%= review.body %>">
       <%= review.body %>
     </li>
   <% end %>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -1,11 +1,15 @@
-
+<div data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
 <%= search_form_for @q, url: url, html: { id: "searchForm", class: "max-w-md mx-auto w-11/12 pt-6" }  do |f| %>
     <label for="" class="mb-2 text-sm font-medium text-secondary sr-only dark:text-white">検索</label>
     <div class="relative">
         <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
         <i class="ph ph-magnifying-glass text-secondary"></i>
         </div>
-        <%= f.search_field :name_or_address_cont, class: 'block w-full p-4 ps-10 text-sm text-secondary border border-secondary rounded-full bg-white focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
+        <%= f.search_field :name_or_address_cont, data: { autocomplete_target: 'input' }, class: 'block w-full p-4 ps-10 text-sm text-secondary border border-secondary rounded-full bg-white focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
+        <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
+        <%= f.hidden_field :address, data: { autocomplete_target: 'hidden' } %>
         <%= f.submit '検索', class: 'text-white absolute end-2 py-2 bottom-2.5 bg-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-primary font-medium rounded-full text-sm px-4 py-0.5' %>
+        <ul class="list-group" data-autocomplete-target="results"></ul>
     </div>
 <% end %>
+</div>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -2,13 +2,13 @@
 <%= search_form_for @q, url: url, html: { id: "searchForm", class: "max-w-md mx-auto w-11/12 pt-6" }  do |f| %>
     <label for="" class="mb-2 text-sm font-medium text-secondary sr-only dark:text-white">検索</label>
     <div class="relative">
-        <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
+        <div class="absolute inset-y-4 start-0 flexed items-center ps-3 pointer-events-none">
         <i class="ph ph-magnifying-glass text-secondary"></i>
         </div>
         <%= f.search_field :name_or_address_cont, data: { autocomplete_target: 'input' }, class: 'block w-full p-4 ps-10 text-sm text-secondary border border-secondary rounded-full bg-white focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
         <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
         <%= f.hidden_field :address, data: { autocomplete_target: 'hidden' } %>
-        <%= f.submit '検索', class: 'text-white absolute end-2 py-2 bottom-2.5 bg-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-primary font-medium rounded-full text-sm px-4 py-0.5' %>
+        <%= f.submit '検索', class: 'text-white absolute fixed inset-y-2 end-2 py-2 h-9 bg-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-primary font-medium rounded-full text-sm px-4 py-0.5' %>
         <ul class="list-group" data-autocomplete-target="results"></ul>
     </div>
 <% end %>

--- a/app/views/shared/_search.html.erb
+++ b/app/views/shared/_search.html.erb
@@ -9,7 +9,7 @@
         <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
         <%= f.hidden_field :address, data: { autocomplete_target: 'hidden' } %>
         <%= f.submit '検索', class: 'text-white absolute fixed inset-y-2 end-2 py-2 h-9 bg-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-primary font-medium rounded-full text-sm px-4 py-0.5' %>
-        <ul class="list-group" data-autocomplete-target="results"></ul>
+        <ul class="list-group absolute w-full bg-white p-2 shadow z-[1] rounded-box" data-autocomplete-target="results"></ul>
     </div>
 <% end %>
 </div>

--- a/app/views/spots/_review.html.erb
+++ b/app/views/spots/_review.html.erb
@@ -1,5 +1,21 @@
-<div class="flex flex-col gap-3 px-4 py-6 md:p-6 space-y-2 justify-center">
-    <div class="flex w-full justify-between">
+<div class="flex flex-col gap-3 px-4 py-6 md:p-6 space-y-2 justify-center border-b md:border md:shadow-sm md:rounded-xl md:hover:shadow-lg">
+    <h3 class="font-bold flex items-center justify-start w-full font-zenmaru text-neutral"><i class="ph ph-chat-circle-text fa-lg"></i>&nbsp;<%= review.spot.name %></h3>
+    <div class="-ml-2 flex gap-0.5 pl-2">  
+        <% rating = review.rating %>
+        <% full_stars = rating %>
+        <% empty_stars = 5 - rating %>
+        
+        <% full_stars.times do %>
+            <i class="ph-fill ph-star fa-lg text-yellow-400"></i>
+        <% end %>
+        
+        <% empty_stars.times do %>
+            <i class="ph-fill ph-star fa-lg text-gray-100"></i>
+        <% end %>
+    </div>
+      <!-- stars - end -->
+    <p class="text-secondary"><%= review.body %></p>
+        <div class="flex w-full justify-between">
         <div class="flex items-center">
             <div>
                 <% if review.user.avatar.present? %>
@@ -19,21 +35,6 @@
             <% end %>
         </div>
     </div>
-    <div class="-ml-1 flex gap-0.5">  
-        <% rating = review.rating %>
-        <% full_stars = rating %>
-        <% empty_stars = 5 - rating %>
-        
-        <% full_stars.times do %>
-            <i class="ph-fill ph-star fa-lg text-yellow-400"></i>
-        <% end %>
-        
-        <% empty_stars.times do %>
-            <i class="ph-fill ph-star fa-lg text-gray-100"></i>
-        <% end %>
-    </div>
-      <!-- stars - end -->
-    <p class="text-secondary"><%= review.body %></p>
     <% unless review.user == current_user %>
         <div class="flex justify-center space-x-2">
             <button class="bg-primary text-secondary text-sm px-3 drop-shadow-md py-2 rounded-lg flex mx-auto items-center justify-center">

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -50,7 +50,7 @@
 
             <div id="reviews-tab" class="hidden bg-white p-4 w-full border-l border-b border-r rounded-l-lg rounded-b-lg" data-tabs-target="panel">
                 <div class="w-full mx-auto h-screen md:h-full mb-16 md:mb-0">
-                <div data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
+                <div data-controller="autocomplete" data-autocomplete-url-value="/reviews/search" role="combobox">
                 <%= search_form_for @q_reviews, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto py-8" }  do |f| %>
                     <label for="" class="mb-2 text-sm font-medium h-full text-secondary sr-only dark:text-white">検索</label>
                     <div class="nav-down text-secondary flex items-center h-12">
@@ -71,12 +71,13 @@
                         <%= f.hidden_field :spot_address, data: { autocomplete_target: 'hidden' } %>
                         <%= f.hidden_field :body, data: { autocomplete_target: 'hidden' } %>
                         <%= f.submit class: 'absolute top-0 end-0 p-2.5 text-sm font-medium h-full text-white bg-accent rounded-e-lg border border-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-secondary dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800' %>
+                        <ul class="list-group absolute w-full bg-white p-2 shadow z-[1] rounded-box" data-autocomplete-target="results"></ul>
                     </div>
                     </div>
                     </div>
                 <% end %>
                     <% if @reviews.present? %>
-                        <div class="md:grid md:grid-cols-3 md:gap-4">
+                        <div class="md:grid md:grid-cols-3 md:gap-4 md:mb-50">
                             <% @reviews.each do |review| %>
                                 <%= render 'spots/review', review: review %>
                             <% end %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -50,6 +50,7 @@
 
             <div id="reviews-tab" class="hidden bg-white p-4 w-full border-l border-b border-r rounded-l-lg rounded-b-lg" data-tabs-target="panel">
                 <div class="w-full mx-auto h-screen md:h-full mb-16 md:mb-0">
+                <div data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
                 <%= search_form_for @q_reviews, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto py-8" }  do |f| %>
                     <label for="" class="mb-2 text-sm font-medium h-full text-secondary sr-only dark:text-white">検索</label>
                     <div class="nav-down text-secondary flex items-center h-12">
@@ -65,8 +66,12 @@
                         <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
                         <i class="ph ph-magnifying-glass text-secondary"></i>
                         </div>
-                        <%= f.search_field :spot_name_or_spot_address_or_body_cont, class: 'block w-full p-4 ps-10 h-full text-sm text-secondary border rounded-e-lg bg-white focus:ring-secondary focus:border-secondary dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
+                        <%= f.search_field :spot_name_or_spot_address_or_body_cont, data: { autocomplete_target: 'input' }, class: 'block w-full p-4 ps-10 h-full text-sm text-secondary border rounded-e-lg bg-white focus:ring-secondary focus:border-secondary dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
+                        <%= f.hidden_field :spot_name, data: { autocomplete_target: 'hidden' } %>
+                        <%= f.hidden_field :spot_address, data: { autocomplete_target: 'hidden' } %>
+                        <%= f.hidden_field :body, data: { autocomplete_target: 'hidden' } %>
                         <%= f.submit class: 'absolute top-0 end-0 p-2.5 text-sm font-medium h-full text-white bg-accent rounded-e-lg border border-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-secondary dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800' %>
+                    </div>
                     </div>
                     </div>
                 <% end %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -12,6 +12,7 @@
 
             <div id="details-tab" class="hidden bg-white py-4 px-4 w-full h-full mb-12 md:mb-0 border-l border-b border-r rounded-b-lg rounded-r-lg" data-tabs-target="panel">
                 <div class="w-full mx-auto md:h-full h-screen pb-8 ">
+                <div data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
                 <%= search_form_for @q_spots, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto py-8" }  do |f| %>
                     <label for="" class="mb-2 text-sm font-medium h-full text-secondary sr-only dark:text-white">検索</label>
                     <div class="nav-down text-secondary flex items-center h-12">
@@ -27,8 +28,12 @@
                         <div class="absolute inset-y-0 start-0 flex items-center ps-3 pointer-events-none">
                         <i class="ph ph-magnifying-glass text-secondary"></i>
                         </div>
-                        <%= f.search_field :name_or_address_cont, class: 'block w-full p-4 ps-10 h-full text-sm text-secondary border rounded-e-lg bg-white focus:ring-secondary focus:border-secondary dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
+                        <%= f.search_field :name_or_address_cont, data: { autocomplete_target: 'input' }, class: 'block w-full p-4 ps-10 h-full text-sm text-secondary border rounded-e-lg bg-white focus:ring-secondary focus:border-secondary dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
+                        <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
+                        <%= f.hidden_field :address, data: { autocomplete_target: 'hidden' } %>
                         <%= f.submit class: 'absolute top-0 end-0 p-2.5 text-sm font-medium h-full text-white bg-accent rounded-e-lg border border-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-secondary dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800' %>
+                        <ul class="list-group absolute w-full bg-white p-2 shadow z-[1] rounded-box" data-autocomplete-target="results"></ul>
+                    </div>
                     </div>
                     </div>
                 <% end %>

--- a/app/views/spots/search.html.erb
+++ b/app/views/spots/search.html.erb
@@ -1,0 +1,13 @@
+<% if @search_by_name %>
+  <% @spots.each do |spot| %>
+    <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.name %>">
+      <%= spot.name %>
+    </li>
+  <% end %>
+<% elsif @search_by_address %>
+  <% @spots.each do |spot| %>
+    <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.address %>">
+      <%= spot.address %>
+    </li>
+  <% end %>
+<% end %>

--- a/app/views/spots/search.html.erb
+++ b/app/views/spots/search.html.erb
@@ -1,12 +1,12 @@
 <% if @search_by_name %>
   <% @spots.each do |spot| %>
-    <li class="w-80 bg-white flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-secondary apitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.name %>">
+    <li class="bg-white flex items-center gap-x-3.5 py-2 px-3 text-sm text-secondary capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.name %>">
       <%= spot.name %>
     </li>
   <% end %>
 <% elsif @search_by_address %>
   <% @spots.each do |spot| %>
-    <li class="w-80 bg-white flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-secondary apitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.address %>">
+    <li class="bg-white flex items-center gap-x-3.5 py-2 px-3 text-sm text-secondary capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.address %>">
       <%= spot.address %>
     </li>
   <% end %>

--- a/app/views/spots/search.html.erb
+++ b/app/views/spots/search.html.erb
@@ -1,12 +1,12 @@
 <% if @search_by_name %>
   <% @spots.each do |spot| %>
-    <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.name %>">
+    <li class="w-80 bg-white flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-secondary apitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.name %>">
       <%= spot.name %>
     </li>
   <% end %>
 <% elsif @search_by_address %>
   <% @spots.each do |spot| %>
-    <li class="w-80 flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-gray-800 hover:bg-blue-200 focus:ring-2 focus:ring-blue-500 dark:text-gray-400 dark:hover:bg-blue-200 dark:hover:text-gray-300" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.address %>">
+    <li class="w-80 bg-white flex items-center gap-x-3.5 py-2 px-3 rounded-md text-sm text-secondary apitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100" role="option" data-autocomplete-value="<%= spot.id %>" data-autocomplete-label="<%= spot.address %>">
       <%= spot.address %>
     </li>
   <% end %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -105,8 +105,8 @@
               <div class="lg:col-span-2 md:mr-8">
             <%= turbo_frame_tag 'review_modal' do %>
               <h2 class="my-3 text-xl font-zenmaru font-bold text-neutral border-bottom">口コミ一覧</h2>
-              <div class="grid divide-y">
-              <div id="reviews">
+              <div class="grid">
+              <div id="reviews" class="space-y-8 divide-gray-200" >
               <%= render @reviews %>
               </div>
               <%= paginate @reviews %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
     collection do
       get :bookmarks
       get :map
+      get :search
     end
   end
   resources :spot_bookmarks, only: %i[create destroy]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,11 @@ Rails.application.routes.draw do
   get 'terms_of_use', to: 'static_pages#terms_of_use'
   get 'spots/list', to: 'spots#list'
   resources :spots, only: %i[index show] do
-    resources :reviews, only: %i[new create edit update destroy]
+    resources :reviews, only: %i[new create edit update destroy] do
+      collection do
+        get :search
+      end
+    end
     collection do
       get :bookmarks
       get :map

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,12 +11,9 @@ Rails.application.routes.draw do
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'terms_of_use', to: 'static_pages#terms_of_use'
   get 'spots/list', to: 'spots#list'
+  get 'reviews/search', to: 'reviews#search'
   resources :spots, only: %i[index show] do
-    resources :reviews, only: %i[new create edit update destroy] do
-      collection do
-        get :search
-      end
-    end
+    resources :reviews, only: %i[new create edit update destroy]
     collection do
       get :bookmarks
       get :map

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "daisyui": "^4.10.1",
     "esbuild": "^0.21.4",
     "postcss": "^8.4.38",
+    "stimulus-autocomplete": "^3.1.0",
     "tailwind": "^4.0.0",
     "tailwindcss": "^3.4.3",
     "tailwindcss-stimulus-components": "^5.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2166,6 +2166,11 @@ stethoskop@1.0.0:
   dependencies:
     node-statsd "0.1.1"
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"


### PR DESCRIPTION
# 概要
- 検索フォームのオートコンプリート
- ローディングスピナー → うまくいかず断念

## 実装画面
### オートコンプリート
[![Image from Gyazo](https://i.gyazo.com/4047cb1e2b2eda7084a1ca6ebf28f0e8.gif)](https://gyazo.com/4047cb1e2b2eda7084a1ca6ebf28f0e8)

## 今後の課題
### オートコンプリート
オートコンプリート内の検索候補をhoverしても色が変わらないので修正する。
### ローディングスピナー
mapの読み込みが完了するまでローディングアニメーションを表示させたかったが、このページのturboをfalseにしているため、turbo flameによるローディングアニメーションは実装できないようでした。
そのため、stimulusを使用して実装しましたが、mapのロード完了後にローディングアニメーションをhiddenにするイベントが発火せず一旦断念。実装方法を再検討し、本リリース時に実装したいと思います。