### PR TITLE
157 不適切な画像の制限

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -8,7 +8,9 @@ class SpotsController < ApplicationController
     @spots = @q_spots.result(distinct: true).includes(:spot_images, :category).page(params[:page]).per(12)
     
     @q_reviews = Review.ransack(params[:q])
-    @reviews = @q_reviews.result(distinct: true).includes(:spot).page(params[:page]).per(12)
+    filtered_reviews = @q_reviews.result(distinct: false).includes(:spot)
+    distinct_reviews = filtered_reviews.select('DISTINCT ON (reviews.id) reviews.id, reviews.user_id, reviews.spot_id, reviews.rating, reviews.body, reviews.created_at, reviews.updated_at, reviews.images')
+    @reviews = distinct_reviews.page(params[:page]).per(12)
   end
 
   def map

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -22,7 +22,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 def update
   self.resource = resource_class.to_adapter.get!(send(:"current_#{resource_name}").to_key)
 
-  if resource.update(account_update_params)
+  if validate_avatar(account_update_params[:avatar]) && resource.update(account_update_params)
     redirect_to users_show_path(current_user)
     flash.now[:notice] = "ユーザー情報を更新しました"
   else
@@ -53,6 +53,18 @@ end
     devise_parameter_sanitizer.sanitize(:account_update)
   end
 
+  def validate_avatar(avatar)
+    return true if avatar.blank?
+
+    result = Vision.image_analysis(avatar)
+
+    unless result
+      flash[:error] = '不適切な画像です'
+      return false
+    end
+
+    true
+  end
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_up_params
   #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])

--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -186,7 +186,12 @@ function updateInfoCard(spot) {
   var infoCard = document.getElementById(infoCardId);
   if (infoCard) {
     infoCard.classList.remove('hidden');
-    const imageUrl = `https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=${spot.image}&key=${apiKey}`;
+    let imageUrl;
+    if (!spot.image || spot.image === 'default.png') {
+      imageUrl = window.defaultImagePath; // デフォルト画像のURL
+    } else {
+      imageUrl = `https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=${spot.image}&key=${apiKey}`;
+    }
     infoCard.querySelector(`#spotImage-${spot.id}`).src = imageUrl;
     infoCard.querySelector(`#spotName-${spot.id}`).textContent = spot.name;
     infoCard.querySelector(`#spotRating-${spot.id}`).textContent = `⭐️ ${spot.rating}`;
@@ -271,7 +276,12 @@ function updateSpotsList(categoryId) {
         frame.innerHTML = '';  // Frame の内容をクリア
 
         data.forEach(spot => {
-            const imageUrl = `https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=${spot.image}&key=${apiKey}`;
+          let imageUrl;
+          if (!spot.image || spot.image === 'default.png') {
+            imageUrl = window.defaultImagePath; // デフォルト画像のURL
+          } else {
+            imageUrl = `https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=${spot.image}&key=${apiKey}`;
+          }
             const spotElement = document.createElement('div');
             spotElement.className = 'spot-item';
             spotElement.innerHTML = `

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -1,7 +1,11 @@
 <div class="bg-white shadow-sm flex md:flex-col mx-auto w-full h-full border rounded-xl md:mb-50 hover:shadow-lg group my-3">
     <div class="flex-shrink-0 rounded-l-xl md:rounded-t-xl md:rounded-b-none relative overflow-hidden h-32 w-1/3 md:h-42 md:w-full md:rounded-t-xl">
         <%= link_to spot_path(spot), data: { turbo: false } do %>
+        <% if spot.spot_images.present? %>
         <img src="https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=<%= spot.spot_images.first.image %>&key=<%= ENV['GMAP_API_KEY'] %>" class="w-full h-full absolute rounded-l-xl md:rounded-t-xl md:rounded-b-none top-0 left-0 md:left-none object-cover transition-transform duration-200 ease-in-out group-hover:scale-110 group-hover:rounded-xl" alt="Image Description">
+        <% else %>
+        <% image_tag('default.png', class: "w-full h-full absolute rounded-l-xl md:rounded-t-xl md:rounded-b-none top-0 left-0 md:left-none object-cover transition-transform duration-200 ease-in-out group-hover:scale-110 group-hover:rounded-xl")%>
+        <% end %>
         <% end %>
     </div>
     <div class="flex flex-wrap w-full md:h-full">

--- a/app/views/spots/map.html.erb
+++ b/app/views/spots/map.html.erb
@@ -88,7 +88,7 @@
                   <i class="ph ph-x"></i>
                 </button>  
                 <div class="flex-shrink-0 relative overflow-hidden h-33 w-32 md:w-1/3 md:rounded-se-none">
-                  <img id="spotImage-<%= spot.id %>" class="w-full h-full absolute top-0 rounded-l-xl left-0 object-cover transition-transform duration-200 ease-in-out group-hover:scale-110 group-hover:rounded-l-xl" src="" alt="Image Description">
+                    <img id="spotImage-<%= spot.id %>" class="w-full h-full absolute top-0 rounded-l-xl left-0 object-cover transition-transform duration-200 ease-in-out group-hover:scale-110 group-hover:rounded-l-xl" src="" alt="Image Description">
                 </div>
                 <div class="flex flex-wrap">
                   <div class="p-4 flex flex-col h-full sm:p-7">
@@ -108,6 +108,10 @@
       </div>
     </div>
   </div>
+
+<script>
+  window.defaultImagePath = "<%= asset_path('default.png') %>";
+</script>
 
 <%= javascript_include_tag "gmap" %>
 

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -1,0 +1,83 @@
+<div class="bg-primary relative md:pb-16 md:mb-0 mb-20">
+
+
+
+<div class="flex flex-col items-center justify-center w-full md:pt-20">
+<div class="md:w-11/12 w-full">
+<div data-controller="tabs rounded-t-lg" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-lg">
+  <ul class="list-reset flex border-b rounded-t-lg">
+    <li class="-mb-px mr-1 w-1/2 bg-white rounded-t-lg text-center" data-tabs-target="tab" data-action="click->tabs#change">
+      <a class="bg-white inline-block py-2 px-4 rounded-t-lg text-secondary hover:text-neutral font-semibold no-underline rounded-t-lg" href="#">ユーザー情報</a>
+    </li>
+    <li class="mr-1 w-1/2 bg-white rounded-t-lg text-center" data-tabs-target="tab" data-action="click->tabs#change">
+      <a class="bg-white inline-block py-2 px-4 rounded-t-lg text-secondary hover:text-neutral font-semibold no-underline rounded-t-lg" href="#">口コミ一覧</a>
+    </li>
+  </ul>
+
+  <div class="hidden bg-white py-4 px-4 w-full border-l border-b border-r rounded-b-lg rounded-r-lg" data-tabs-target="panel">
+            <div class="w-11/12 mx-auto divide-y space-y-8 pb-8">
+        <div class="justify-start grid grid-flow-col gap-8 mt-10">
+            <div class="avatar">
+                <div class="w-24 rounded-full">
+                <% if @user.avatar.present? %>
+                    <%= image_tag @user.avatar.url %>
+                <% else %>
+                    <%= image_tag("default.png") %>
+                <% end %>
+                </div>
+            </div>
+            <h2 class="text-xl font-zenmaru font-bold text-neutral flex items-center"><%= @user.name %></h2>
+        </div>
+    </div>
+
+    <div class="w-full py-2 mt-2 origin-top-right bg-white dark:bg-gray-800 text-secondary">
+        <div class= "flex items-center p-3 text-sm capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:text-white" onclick="my_modal_3.showModal()" >
+            <p><i class="ph ph-pencil-simple fa-lg mr-1 fa-lg"></i> ユーザー情報編集</p>
+        
+        </div>
+        <%= link_to terms_of_use_path, class: "md:hidden flex items-center p-3 text-sm capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:text-white" do %>
+            <p><i class="ph ph-file-text fa-lg mr-1"></i> 利用規約</p>
+        <% end %>
+        <%= link_to privacy_policy_path, class: "md:hidden flex items-center p-3 text-sm capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:text-white" do %>
+            <p><i class="ph ph-lock-key fa-lg mr-1"></i> プライバシーポリシー</p>
+        <% end %>
+        <%= link_to "https://twitter.com/819Chapchon", class: "md:hidden flex items-center p-3 text-sm capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:text-white" do %>
+            <p><i class="ph ph-envelope-simple fa-lg mr-1"></i> お問い合わせ</p>
+        <% end %>
+        <%= link_to destroy_user_session_path, class: "flex items-center p-3 text-sm capitalize transition-colors duration-300 transform dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-gray-700 dark:hover:text-white", data: { turbo_method: :delete } do %>
+            <p><i class="ph ph-sign-out fa-lg mr-1"></i> ログアウト</p>
+        <% end %>
+                    <dialog id="my_modal_3" class="modal">
+                <div class="modal-box">
+                    <form method="dialog">
+                        <button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">✕</button>
+                    </form>
+                    <%= render 'users/registrations/edit'%>
+                </div>
+            </dialog>
+    </div>
+  </div>
+
+  <div class="hidden bg-white py-4 px-4 w-full border-l border-b border-r rounded-l-lg rounded-b-lg" data-tabs-target="panel">
+    <div class="w-11/12 mx-auto divide-y space-y-8 pb-8">
+        <h2 class="text-xl font-zenmaru font-bold text-neutral"><%= @user.name %>の口コミ一覧</h2>
+        <% if @reviews.present? %>
+            <%= render "users/reviews" %>
+            <%= paginate @reviews %>
+        <% else %>
+            <div class="mx-auto flex w-1/2 flex-col items-center gap-2.5 justify-center w-3/5">
+                <%= image_tag("936.png", class: "h-full md:h-64 md:w-56 flex items-center justify-center") %>
+                <h3 class="font-bold flex items-center justify-center w-full font-zenmaru text-neutral"> <i class="ph ph-empty fa-lg"></i>  まだ投稿がありません</h3>
+                <p class="text-sm flex items-center justify-center w-full text-secondary">レビューや猫スポットを投稿してさらに猫スポットを楽しもう！</p>
+                <%= link_to "#", class: "block w-full" do %>
+                    <button class="bg-accent text-white px-3 py-2 rounded-full flex mx-auto items-center justify-center w-full md:w-1/2">
+                        <p><i class="ph ph-chat-circle-dots fa-lg"></i> 口コミを投稿する</p>
+                    </button>
+                <% end %>
+            </div>
+        <% end %>
+        </div>
+    </div>
+</div>
+</div>
+</div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,6 +29,7 @@ module App
     config.autoload_lib(ignore: %w(assets tasks))
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
+    config.paths.add "lib", eager_load: true
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/lib/vision.rb
+++ b/lib/vision.rb
@@ -1,0 +1,45 @@
+require "base64"
+require "json"
+require "net/https"
+
+module Vision
+  class << self
+    def image_analysis(image_file)
+      api_url = "https://vision.googleapis.com/v1/images:annotate?key=#{ENV['VISION_API_KEY']}"
+      base64_image = Base64.encode64(image_file.tempfile.read)
+      params = {
+        requests: [{
+          image: {
+            content: base64_image
+          },
+          features: [
+            {
+              type: "SAFE_SEARCH_DETECTION"
+            }
+          ]
+        }]
+      }.to_json
+      uri = URI.parse(api_url)
+      https = Net::HTTP.new(uri.host, uri.port)
+      https.use_ssl = true
+      request = Net::HTTP::Post.new(uri.request_uri)
+      request["Content-Type"] = "application/json"
+      response = https.request(request, params)
+      result = JSON.parse(response.body)
+      puts "API response: #{result}"  # レスポンスのログ出力
+      if (error = result["responses"][0]["error"]).present?
+        raise error["message"]
+      else
+        result_arr = result["responses"].flatten.map do |parsed_image|
+          parsed_image["safeSearchAnnotation"].values
+        end.flatten
+        puts "Parsed result: #{result_arr}"  # パースした結果のログ出力
+        if result_arr.include?("LIKELY") || result_arr.include?("VERY_LIKELY") || result_arr.include?("POSSIBLE")
+          false
+        else
+          true
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# 概要
## Google Cloud Vision APIを用いて不適切な画像をフィルタリング
以下の２箇所でバリデーションを設定
- レビューの投稿画像
- Userのavatar

## SpotImageが保存されなかった場合のデフォルト画像を設定
- infoCardと近い順リストのデフォルト画像はerbでscriptを書いてasset_parhをJSに渡すというゴリ押しの方法で実装。今後改善する。