### PR TITLE
167 タグ機能

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -9,6 +9,7 @@ class ReviewsController < ApplicationController
 
   def create
     @review = current_user.reviews.build(review_params)
+    # フォームから送信されたタグの情報を取り出す。空の場合は[]を使う
     tag_ids_param = params[:review][:tag_ids].first || "[]"
     tag_list = JSON.parse(tag_ids_param).map { |tag| tag["value"] }
     Rails.logger.debug "tag_list: #{tag_list.inspect}"
@@ -31,7 +32,7 @@ class ReviewsController < ApplicationController
   end
 
   def edit
-    @tag_list = @review.review_tags.joins(:tag).pluck('tags.name').join(',')
+    @tag_list = @review.review_tags.joins(:tag).pluck('tags.name').join(', ')
   end
 
   def update
@@ -54,8 +55,9 @@ class ReviewsController < ApplicationController
         @review.remove_image_at_index(index.to_i)
       end
     end
-    # タグのIDリストをカンマで分割して配列にする
-    tag_list = params[:review][:tag_ids].split(',')
+    # 投稿されたタグの情報を取り出す。空の場合は[]を使う
+    tag_ids_param = params[:review][:tag_ids].first || "[]"
+    tag_list = JSON.parse(tag_ids_param).map { |tag| tag["value"] }
 
     # 画像のバリデーションが成功し、レビューが保存できた場合
     if validate_images(review_params[:images]) && @review.save

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -9,7 +9,9 @@ class ReviewsController < ApplicationController
 
   def create
     @review = current_user.reviews.build(review_params)
-    tag_list = params[:review][:tag_ids].split(',')
+    tag_ids_param = params[:review][:tag_ids].first || "[]"
+    tag_list = JSON.parse(tag_ids_param).map { |tag| tag["value"] }
+    Rails.logger.debug "tag_list: #{tag_list.inspect}"
     if validate_images(review_params[:images]) && @review.save
       reviews_data
       @review.save_tags(tag_list)

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -9,8 +9,10 @@ class ReviewsController < ApplicationController
 
   def create
     @review = current_user.reviews.build(review_params)
+    tag_list = params[:review][:tag_ids].split(',')
     if validate_images(review_params[:images]) && @review.save
       reviews_data
+      @review.save_tags(tag_list)
       flash.now[:success] = "口コミを投稿しました"
       render turbo_stream: [
         turbo_stream.prepend("reviews", partial: "reviews/review", locals: { review: @review }),
@@ -127,7 +129,7 @@ end
     end
 
     if inappropriate_images.any?
-      flash[:error] = '不適切な画像が含まれています'
+      flash[:alert] = '不適切な画像が含まれています'
       return false
     end
 

--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -87,8 +87,15 @@ class SpotsController < ApplicationController
   def show
     @user = current_user
     @spot = Spot.find(params[:id])
+    Rails.logger.debug "Received tag_id: #{params[:tag_id]}" # デバッグ用ログ
     @review = Review.new(spot: @spot)
-    @reviews = @spot.reviews.includes(:user).order(created_at: :desc).page(params[:page]).per(10)
+    if params[:tag_id].present?
+      @reviews = @spot.reviews.joins(:tags).where(tags: { id: params[:tag_id] }).includes(:user).order(created_at: :desc).page(params[:page]).per(10)
+      logger.debug "Filtered reviews for tag_id: #{params[:tag_id]}"
+    else
+      @reviews = @spot.reviews.includes(:user).order(created_at: :desc).page(params[:page]).per(10)
+      logger.debug "No tag_id provided, showing all reviews"
+    end
     @all_reviews_count = @spot.reviews.count
     @average_rating = @spot.reviews.average(:rating).to_f
     @prioritized_image = @spot.prioritized_spot_image # 優先的に表示する画像を取得

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,0 +1,9 @@
+class TagsController < ApplicationController
+    def search
+        query = params[:query]
+        @tags = Tag.where("name LIKE ?", "%#{query}%")
+        #　値を取得する
+        @tags = @tags.pluck(:name)
+        render json: @tags
+    end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -76,14 +76,4 @@ module ApplicationHelper
         "bronze.png"
       end
     end
-
-    def icon_circle_color(user)
-      case user_rank(user)
-      when 'gold'
-        "p-4 text-sm text-blue-800 rounded-lg bg-blue-50 dark:bg-gray-800 dark:text-blue-400"
-      when :alert  then "p-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400"
-      when :success  then "p-4 text-sm text-green-800 rounded-lg bg-green-50 dark:bg-gray-800 dark:text-green-400"
-      else "p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400"
-      end
-    end
   end

--- a/app/helpers/tags_helper.rb
+++ b/app/helpers/tags_helper.rb
@@ -1,0 +1,2 @@
+module TagsHelper
+end

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -27,3 +27,6 @@ application.register("search-accordion", SearchAccordionController)
 
 import SidebarController from "./sidebar_controller"
 application.register("sidebar", SidebarController)
+
+import TagsController from "./tags_controller"
+application.register("tags", TagsController)

--- a/app/javascript/controllers/tags_controller.js
+++ b/app/javascript/controllers/tags_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+import Tagify from '@yaireo/tagify'
+
+// Connects to data-controller="tags"
+export default class extends Controller {
+  connect() {
+    var input = document.querySelector('input[name="review[tag_ids][]"]');
+
+    // initialize Tagify on the above input node reference
+    new Tagify(input)
+  }
+}

--- a/app/javascript/controllers/tags_controller.js
+++ b/app/javascript/controllers/tags_controller.js
@@ -4,9 +4,29 @@ import Tagify from '@yaireo/tagify'
 // Connects to data-controller="tags"
 export default class extends Controller {
   connect() {
-    var input = document.querySelector('input[name="review[tag_ids][]"]');
+    var input = document.querySelector('input[name="review[tag_ids][]"]'),
+    tagify = new Tagify(input, {whitelist:[]}),
+    controller; // for aborting the call
 
-    // initialize Tagify on the above input node reference
-    new Tagify(input)
-  }
+// listen to any keystrokes which modify tagify's input
+tagify.on('input', onInput)
+
+function onInput( e ){
+  var value = e.detail.value
+  tagify.whitelist = null // reset the whitelist
+
+  // https://developer.mozilla.org/en-US/docs/Web/API/AbortController/abort
+  controller && controller.abort()
+  controller = new AbortController()
+
+  // show loading animation.
+  tagify.loading(true)
+
+  fetch(`/tags/search?query=${value}`, {signal:controller.signal})
+    .then(RES => RES.json())
+    .then(function(newWhitelist){
+      tagify.whitelist = newWhitelist // update whitelist Array in-place
+      tagify.loading(false).dropdown.show(value) // render the suggestions dropdown
+    })
+  }}
 }

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -26,6 +26,13 @@ class Review < ApplicationRecord
     ["spot", "user"]
   end
 
+  def save_tags(save_review_tags) #カラムの中から同じ値がないか探して、あればそのままfindの動き、なければcreateの動きで新たにカラムに保存
+    save_review_tags.each do |new_name|
+      review_tag = Tag.find_or_create_by(name: new_name)
+      self.tags << review_tag
+    end
+  end
+
   private
 
   def validate_image_count

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -26,11 +26,14 @@ class Review < ApplicationRecord
     ["spot", "user"]
   end
 
-  def save_tags(save_review_tags) #カラムの中から同じ値がないか探して、あればそのままfindの動き、なければcreateの動きで新たにカラムに保存
-    save_review_tags.each do |new_name|
-      review_tag = Tag.find_or_create_by(name: new_name)
-      self.tags << review_tag
-    end
+  def save_tags(save_review_tags)
+  # 既存のタグをクリアすることで、タグ編集時の重複を防ぐ
+  self.tags.clear
+
+  save_review_tags.each do |new_name| #カラムの中から同じ値がないか探して、あればそのままfindの動き、なければcreateの動きで新たにカラムに保存
+    review_tag = Tag.find_or_create_by(name: new_name)
+    self.tags << review_tag #タグを関連付ける
+  end
   end
 
   private

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -2,6 +2,8 @@ class Review < ApplicationRecord
   belongs_to :user
   belongs_to :spot
   has_many :helpfuls, dependent: :destroy
+  has_many :review_tags, dependent: :destroy
+  has_many :tags, through: :review_tags
   attr_accessor :images_cache
   mount_uploaders :images, ImageUploader
 

--- a/app/models/review_tag.rb
+++ b/app/models/review_tag.rb
@@ -1,4 +1,5 @@
 class ReviewTag < ApplicationRecord
   belongs_to :tag
   belongs_to :review
+  validates :tag_id, uniqueness: { scope: :review_id }
 end

--- a/app/models/review_tag.rb
+++ b/app/models/review_tag.rb
@@ -1,0 +1,4 @@
+class ReviewTag < ApplicationRecord
+  belongs_to :tag
+  belongs_to :review
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,2 @@
+class Tag < ApplicationRecord
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,5 +1,5 @@
 class Tag < ApplicationRecord
     has_many :review_tags, dependent: :destroy
     has_many :reviews, through: :review_tags
-    variants :name, presence: :true, uniqueness: :true
+    validates :name, presence: :true, uniqueness: :true
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,2 +1,5 @@
 class Tag < ApplicationRecord
+    has_many :review_tags, dependent: :destroy
+    has_many :reviews, through: :review_tags
+    variants :name, presence: :true, uniqueness: :true
 end

--- a/app/views/diagnostics/result.html.erb
+++ b/app/views/diagnostics/result.html.erb
@@ -3,23 +3,23 @@
         <div class="my-8 flex-col items-center justify-center">
             <% if @top_category.present? %>
                 <% result = result_contents(@top_category)%>
-                <h3 class="pl-4 text-secondary font-zenmaru text-center text-xl font-semibold">あなたにおすすめの猫スポットは<h3>
+                <h3 class="text-secondary font-zenmaru text-center text-[16px] font-semibold">あなたにおすすめの猫スポットは<h3>
                 <div class="flex-col justify-center items-center my-8">
                     <div class="flex justify-center items-center">
-                        <h1 class="text-secondary font-zenmaru text-xl font-bold">＼ <%= result[:content] %> ／</h1>
+                        <h1 class="text-secondary font-zenmaru text-[16px] font-bold">＼ <%= result[:content] %> ／</h1>
                     </div>
                     <div class="flex justify-center items-center">
                         <%= image_tag result[:image], :size =>'60x60' %>
-                        <h1 class="pl-2 text-secondary font-zenmaru text-3xl underline font-semibold"><%= @top_category.name %></h1>
+                        <h1 class="text-secondary font-zenmaru text-3xl underline font-semibold"><%= @top_category.name %></h1>
                     </div>
                 </div>
                 <div class="my-8 flex-col items-center justify-center">
                     <% if @recommend_spot.present? %>
                     <div class="flex-col items-center justify-center">
-                        <h1 class="pl-4 text-secondary font-zenmaru text-center text-lg font-semibold">なかでもおすすめの<span><%= @recommend_spot.category.name %></span>はこちら</h1>
+                        <h1 class="text-secondary font-zenmaru text-center text-[16px] font-semibold">なかでもおすすめの<span><%= @recommend_spot.category.name %></span>はこちら</h1>
                         <%= render 'diagnostics/spot' %>
                     <% else %>
-                        <h1 class="pl-4 text-secondary font-zenmaru text-center text-lg font-semibold">おすすめの猫スポットはありませんでした</h1>
+                        <h1 class="text-secondary font-zenmaru text-center text-lg font-semibold">おすすめの猫スポットはありませんでした</h1>
                     <% end %>
                 </div>
                 <div class="flex justify-center items-center space-x-4 my-8">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,9 @@
     <%= turbo_frame_tag 'review_modal' %>
     <%= include_gon %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@yaireo/tagify/dist/tagify.polyfills.min.js"></script>
+    <link href="https://cdn.jsdelivr.net/npm/@yaireo/tagify/dist/tagify.css" rel="stylesheet" type="text/css" />
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swiper@11/swiper-bundle.min.css"/>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" integrity="sha512-SnH5WK+bZxgPHs44uWIX+LLJAJ9/2PkPKZ5QiAj6Ta86w+fsb2TkcmfRyVX3pBnMFcV7oQPJkl9QevSCWr3W6A==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <script src="https://unpkg.com/@phosphor-icons/web"></script>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -35,9 +35,9 @@
     <div class="flex space-x-2">
     <% if review.tags.present? %>
       <% review.tags.each do |tag| %>
-        <div class="inline-flex text-secondary text-xs rounded-lg py-1.5 px-2 bg-primary items-center hover:bg-primary-hover">
-          <i class="ph ph-tag"></i>&nbsp;<%= tag.name %>
-        </div>
+        <%= link_to spot_path(@spot, tag_id: tag.id), data: { turbo_frame: "tags_search" }, class: "inline-flex text-secondary text-xs rounded-lg py-1.5 px-2 bg-primary items-center hover:bg-primary-hover" do %>
+            <i class="ph ph-tag"></i>&nbsp;<%= tag.name %>
+        <% end %>
       <% end %>
     <% end %>
     </div>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -32,11 +32,15 @@
       <% end %>
     </div>
     <p class="text-secondary"><%= review.body %></p>
+    <div class="flex space-x-2">
     <% if review.tags.present? %>
       <% review.tags.each do |tag| %>
-        <%= tag.name %>
+        <div class="inline-flex text-secondary text-xs rounded-lg py-1.5 px-2 bg-primary items-center hover:bg-primary-hover">
+          <i class="ph ph-tag"></i>&nbsp;<%= tag.name %>
+        </div>
       <% end %>
     <% end %>
+    </div>
     <% if review.images.present? %>
       <div class="flex space-x-2">
         <% review.images.each do |image| %>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -32,6 +32,11 @@
       <% end %>
     </div>
     <p class="text-secondary"><%= review.body %></p>
+    <% if review.tags.present? %>
+      <% review.tags.each do |tag| %>
+        <%= tag.name %>
+      <% end %>
+    <% end %>
     <% if review.images.present? %>
       <div class="flex space-x-2">
         <% review.images.each do |image| %>

--- a/app/views/reviews/_review_list.html.erb
+++ b/app/views/reviews/_review_list.html.erb
@@ -21,9 +21,11 @@
     <h2 class="my-3 text-xl font-zenmaru font-bold text-neutral border-bottom">口コミ一覧</h2>
     <div class="grid">
         <div id="reviews" class="space-y-8 divide-gray-200 divide-y" >
+        <%= turbo_frame_tag 'reviews' do %>
             <% spot.reviews.each do |review| %>
-                <%= render partial: "reviews/review", locals: { review: review } %>
+                <%= render partial: "reviews/review",  locals: { review: review, spot: @spot } %>
             <% end %>
+        <% end %>
         </div>
     <%= paginate @reviews %>
     </div>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -47,8 +47,8 @@
                 <%= f.text_area :body, class: "bg-gray-50 border border-gray-300 h-24 text-gray-900 text-sm rounded-lg" %>
                 </div>
                 <div class="relative mb-4 flex flex-col w-full">
-                  <%= f.text_field :tag_ids, class: "form-control", id:'tag_id', value: @tag_list,
-                      placeholder: "タグをつける。複数つけるには','で区切ってください。" %>
+                    <%= f.label :tag_ids, "タグ", class: "mb-2 text-sm text-secondary" %>
+                    <%= text_field_tag 'review[tag_ids][]', @tag_list, autofocus: true, data: { controller: "tags" }, multiple: true, id: 'tag_ids', placeholder: "Enterを押して区切ってください", class: "text-sm rounded-lg" %>
                 </div>
                 <div class="relative mb-4">
                 <%= f.submit "口コミを更新する", class: "bg-accent text-sm text-white px-4 py-2 rounded-full flex mx-auto items-center justify-center w-full" %>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -46,6 +46,10 @@
                 <%= f.label :body, "コメント", class: "mb-2 text-sm text-secondary" %>
                 <%= f.text_area :body, class: "bg-gray-50 border border-gray-300 h-24 text-gray-900 text-sm rounded-lg" %>
                 </div>
+                <div class="relative mb-4 flex flex-col w-full">
+                  <%= f.text_field :tag_ids, class: "form-control", id:'tag_id', value: @tag_list,
+                      placeholder: "タグをつける。複数つけるには','で区切ってください。" %>
+                </div>
                 <div class="relative mb-4">
                 <%= f.submit "口コミを更新する", class: "bg-accent text-sm text-white px-4 py-2 rounded-full flex mx-auto items-center justify-center w-full" %>
                 </div>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -1,6 +1,6 @@
 <%= turbo_frame_tag "review_modal" do %>
     <div class="fixed inset-0 flex items-center justify-center z-50 bg-gray-500 bg-opacity-50" data-controller="review-modal" data-review-modal-target="backGround" data-action="click->review-modal#closeBackground" >
-        <div class="modal-content relative bg-white w-72 rounded-xl shadow-lg p-10 flex flex-col justify-center " data-review-modal-target="reviewModal">
+        <div class="modal-content relative bg-white w-72 rounded-xl shadow-lg p-8 flex flex-col justify-center " data-review-modal-target="reviewModal">
             <div class="absolute top-3 right-4">
                 <i class="ph ph-x h-6 w-6 text-secondary" data-action="click->review-modal#closeModal"></i>
             </div>
@@ -8,7 +8,7 @@
             <%= form_with model: @review, 
                             url: spot_reviews_path(@spot),
                             data: { action: "turbo:submit-end->review-modal#close" },
-                            html: { class: "mx-auto flex flex-col items-center justify-center space-y-8" } do |f| %>
+                            html: { class: "mx-auto flex flex-col items-center justify-center space-y-4" } do |f| %>
                 <%= render 'shared/error_messages', object: f.object %>
                 <div class="relative mb-4 flex flex-col w-full">
                 <%= f.label :rating, "評価", class: "text-sm text-secondary mb-2" %>
@@ -30,8 +30,8 @@
                 <%= f.text_area :body, class: "bg-gray-50 border border-gray-300 h-24 text-gray-900 text-sm rounded-lg" %>
                 </div>
                 <div class="relative mb-4 flex flex-col w-full">
-                    <%= f.text_field :tag_ids, class: "form-control", id:'tag_ids',\
-                        placeholder: "タグをつける。複数つけるには','で区切ってください。" %>
+                <%= f.label :tag_ids, "タグ", class: "mb-2 text-sm text-secondary" %>
+                    <%= text_field_tag 'review[tag_ids][]', '', autofocus: true, data: { controller: "tags" }, multiple: true, id: 'tag_ids', placeholder: "Enterを押して区切ってください", class: "text-sm rounded-lg" %>
                 </div>
                 <div class="relative mb-4">
                 <%= f.submit "口コミを投稿する", class: "bg-accent text-sm text-white px-4 py-2 rounded-full flex mx-auto items-center justify-center w-full" %>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -29,6 +29,10 @@
                 <%= f.label :body, "コメント", class: "mb-2 text-sm text-secondary" %>
                 <%= f.text_area :body, class: "bg-gray-50 border border-gray-300 h-24 text-gray-900 text-sm rounded-lg" %>
                 </div>
+                <div class="relative mb-4 flex flex-col w-full">
+                    <%= f.text_field :tag_ids, class: "form-control", id:'tag_ids',\
+                        placeholder: "タグをつける。複数つけるには','で区切ってください。" %>
+                </div>
                 <div class="relative mb-4">
                 <%= f.submit "口コミを投稿する", class: "bg-accent text-sm text-white px-4 py-2 rounded-full flex mx-auto items-center justify-center w-full" %>
                 </div>

--- a/app/views/reviews/new.html.erb
+++ b/app/views/reviews/new.html.erb
@@ -30,7 +30,7 @@
                 <%= f.text_area :body, class: "bg-gray-50 border border-gray-300 h-24 text-gray-900 text-sm rounded-lg" %>
                 </div>
                 <div class="relative mb-4 flex flex-col w-full">
-                <%= f.label :tag_ids, "タグ", class: "mb-2 text-sm text-secondary" %>
+                    <%= f.label :tag_ids, "タグ", class: "mb-2 text-sm text-secondary" %>
                     <%= text_field_tag 'review[tag_ids][]', '', autofocus: true, data: { controller: "tags" }, multiple: true, id: 'tag_ids', placeholder: "Enterを押して区切ってください", class: "text-sm rounded-lg" %>
                 </div>
                 <div class="relative mb-4">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -169,13 +169,19 @@
             </div>
             <div class="lg:col-span-2 md:mr-8">
               <%= turbo_frame_tag 'review_modal' do %>
+              <%= turbo_frame_tag 'tags_search' do %>
                 <h2 class="my-3 text-xl font-zenmaru font-bold text-neutral border-bottom">口コミ一覧</h2>
+                <%= link_to spot_path(@spot), data: { turbo_frame: "tags_search" }, class: "inline-block text-sm px-4 py-2 mx-auto text-secondary bg-primary rounded-lg hover:bg-primary-hover md:mx-0" do %>
+                  <i class="ph ph-tag"></i>&nbsp;すべて
+                <% end %>
+
                 <div class="grid">
                   <div id="reviews" class="space-y-8 divide-gray-200 divide-y" >
                     <%= render @reviews %>
                   </div>
                   <%= paginate @reviews %>
                 </div>
+              <% end %>
               <% end %>
             </div>
           <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,11 @@ Rails.application.routes.draw do
   resources :spot_bookmarks, only: %i[create destroy]
   resources :helpfuls, only: %i[create destroy]
   resources :visits, only: %i[create destroy]
+  resources :tags, only: %i[] do
+    collection do
+      get :search
+    end
+  end
   resources :diagnostics, only: [] do
     member do
       get 'question', to: 'diagnostics#show_question', as: 'question'

--- a/db/migrate/20240619045203_create_tags.rb
+++ b/db/migrate/20240619045203_create_tags.rb
@@ -1,0 +1,10 @@
+class CreateTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :tags do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+    add_index :tags, :name, unique: true
+  end
+end

--- a/db/migrate/20240619045505_create_review_tags.rb
+++ b/db/migrate/20240619045505_create_review_tags.rb
@@ -1,0 +1,11 @@
+class CreateReviewTags < ActiveRecord::Migration[7.1]
+  def change
+    create_table :review_tags do |t|
+      t.references :tag, null: false, foreign_key: true
+      t.references :review, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :review_tags, [:review_id, :tag_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_16_154955) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_19_045505) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -52,6 +52,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_16_154955) do
     t.datetime "updated_at", null: false
     t.index ["review_id"], name: "index_helpfuls_on_review_id"
     t.index ["user_id"], name: "index_helpfuls_on_user_id"
+  end
+
+  create_table "review_tags", force: :cascade do |t|
+    t.bigint "tag_id", null: false
+    t.bigint "review_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["review_id", "tag_id"], name: "index_review_tags_on_review_id_and_tag_id", unique: true
+    t.index ["review_id"], name: "index_review_tags_on_review_id"
+    t.index ["tag_id"], name: "index_review_tags_on_tag_id"
   end
 
   create_table "reviews", force: :cascade do |t|
@@ -116,6 +126,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_16_154955) do
     t.index ["category_id"], name: "index_spots_on_category_id"
   end
 
+  create_table "tags", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tags_on_name", unique: true
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
@@ -147,6 +164,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_16_154955) do
   add_foreign_key "diagnostic_answers", "diagnostic_questions"
   add_foreign_key "helpfuls", "reviews"
   add_foreign_key "helpfuls", "users"
+  add_foreign_key "review_tags", "reviews"
+  add_foreign_key "review_tags", "tags"
   add_foreign_key "reviews", "spots"
   add_foreign_key "reviews", "users"
   add_foreign_key "spot_bookmarks", "spots"


### PR DESCRIPTION
# 概要
## やったこと
### タグ関連テーブル作成
- tagsテーブルと中間テーブルreview_tagsテーブルを作成し以下のように関連付けを行った
- tagテーブルのnameカラムにNOT NULL制約と一意性制約を付与
- review_tagsテーブルの外部キーにも一意性制約を付与
![image](https://github.com/chapchon819/nekospot/assets/145883659/0dd72c3e-848f-4e31-a3ee-021f091b9733)

### タグ機能実装
- reviewモデルにて'save_tags'メソッドを作成し、新たなタグのみDBに保存しDBにある場合はそのタグを使用するようにした
- タグ入力時のオートコンプリートは[Tagify](https://github.com/yairEO/tagify#ajax-whitelist)を用いて実装した
[![Image from Gyazo](https://i.gyazo.com/ddc34f05111e043799e38a3b32f42656.gif)](https://gyazo.com/ddc34f05111e043799e38a3b32f42656)

### スポット詳細内レビュー一覧のタグ検索機能
- タグを押すと該当のタグのある投稿のみ表示されるようにした
- Turbo Frameを用いて非同期で絞り込みが行われるようにした

[![Image from Gyazo](https://i.gyazo.com/9d9db39181919548230dea07b12cf171.gif)](https://gyazo.com/9d9db39181919548230dea07b12cf171)

### やらなかったこと
- スポット一覧にてタグからスポットを絞り込む機能
→別途issueを立てて取り組みます。

