### PR TITLE
🐛 Fix:TagifyのJSの二重読み込みを解消

### DIFF
--- a/app/javascript/controllers/tags_controller.js
+++ b/app/javascript/controllers/tags_controller.js
@@ -1,5 +1,4 @@
 import { Controller } from "@hotwired/stimulus"
-import Tagify from '@yaireo/tagify'
 
 // Connects to data-controller="tags"
 export default class extends Controller {


### PR DESCRIPTION
# 概要
- TagifyのJSを二重読み込みしていたことによる本番環境での`db:migrate`実行時のbuildエラー解消