### PR TITLE
🐛 Fix:TOPページからだけログインできない不具合を修正

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -1,10 +1,17 @@
 class OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  before_action :log_session_details, only: [:failure, :google_oauth2, :line]
+
     def google_oauth2
+      logger.debug "Entering OmniauthCallbacksController#google_oauth2"
         basic_action
     end
 
     def line
       basic_action
+    end
+
+    def failure
+      redirect_to root_path
     end
   
     private
@@ -23,10 +30,16 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       end
       #ログイン後のflash messageとリダイレクト先を設定
       flash[:notice] = "ログインしました"
-      redirect_to after_sign_in_path_for(resource)
+      redirect_to after_sign_in_path_for(@profile)
     end
   
     def fake_email(uid, provider)
       "#{auth.uid}-#{auth.provider}@example.com"
+    end
+  
+    def log_session_details
+      Rails.logger.info("Session ID: #{session.id}")
+      Rails.logger.info("Session Data: #{session.to_hash}")
+      Rails.logger.info("CSRF Token: #{session[:_csrf_token]}")
     end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -14,9 +14,15 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   # DELETE /resource/sign_out
-  # def destroy
-  #   super
-  # end
+  def destroy
+    # 明示的にRedisからセッションを削除する
+    if session[:session_id]
+      redis_store = ActiveSupport::Cache::RedisStore.new(url: ENV['REDIS_URL'], namespace: 'session')
+      redis_store.delete(session[:session_id])
+    end
+
+    super
+  end
 
   # protected
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -5,7 +5,7 @@ module ApplicationHelper
     base_classes = "p-4 text-sm rounded-lg dark:bg-gray-800"
   
     # ルートとspot_maps_pathを除外する条件
-    if !current_page?(root_path) && !current_page?(map_spots_path) && !current_page?(spot_path(@spot))
+    if !current_page?(root_path) && !current_page?(map_spots_path) && @spot.present? && !current_page?(spot_path(@spot))
       base_classes += " md:mt-[72px]"
     end
   

--- a/app/views/shared/_login_modal.html.erb
+++ b/app/views/shared/_login_modal.html.erb
@@ -21,12 +21,14 @@
           <%= image_tag("line_64.png", alt: "Logo", class: "h-10 mr-4 ") %>
             LINEでログイン
           </button>
+          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
         <% end %>
         <%= link_to user_google_oauth2_omniauth_authorize_path, class: "flex items-center justify-center w-full", method: :post do %>
           <button class="bg-white text-google-text hover:bg-google-hover px-4 py-2 border border-google rounded-full flex items-center w-full justify-center md:w-4/5 text-sm">
           <%= image_tag("g-logo.png", alt: "Logo", class: "h-8 mr-4 ") %>
           Googleでログイン
           </button>
+          <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
         <% end %>
         </div>
       </div>

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,16 +1,24 @@
 if Rails.env.production?
-    Rails.application.config.session_store :redis_store,
+Rails.application.config.session_store :redis_store,
     servers: [
-        {
+    {
         url: ENV['REDIS_URL'],
         namespace: 'session'
-        }
+    }
     ],
     expire_after: 90.minutes,
-    key: "_#{Rails.application.class.module_parent_name.downcase}_session"
+    key: "_#{Rails.application.class.module_parent_name.downcase}_session",
+    threadsafe: true,
+    secure: Rails.env.production?,
+    httponly: true,
+    same_site: :lax
 else
-    Rails.application.config.session_store :redis_store,
+Rails.application.config.session_store :redis_store,
     servers: %w(redis://nekospot-redis-1:6379/0/session),
     expire_after: 90.minutes,
-    key: "_#{Rails.application.class.module_parent_name.downcase}_session"
+    key: "_#{Rails.application.class.module_parent_name.downcase}_session",
+    threadsafe: true,
+    secure: Rails.env.production?,
+    httponly: true,
+    same_site: :lax
 end

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -35,6 +35,7 @@ pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
 plugin :tmp_restart
 
 workers Integer(ENV['WEB_CONCURRENCY'] || 2)
+preload_app!
 
 before_fork do
   require 'puma_worker_killer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,8 +5,13 @@ Rails.application.routes.draw do
   root "static_pages#index"
   devise_for :users, controllers: {
     omniauth_callbacks: "omniauth_callbacks",
-    registrations: 'users/registrations'
+    registrations: 'users/registrations',
+    sessions: 'users/sessions'
   }
+  devise_scope :user do
+    get '/users/sign_out' => 'devise/sessions#destroy'
+    get '/users/auth/failure' => 'omniauth_callbacks#failure'
+  end
   get 'static_pages/index'
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'terms_of_use', to: 'static_pages#terms_of_use'


### PR DESCRIPTION
# 概要
## トップページからだけログインできない不具合を修正
- クッキーとして送られたセッションidがRedisからも削除されるように修正
- `@spot`が存在するかどうか判定するコードを追加
- リクエストURLが`/users`を含まずかつAJAXリクエストでない場合にのみ`session[:previous_url]`に`request.fullpath`を保存するように変更