### PR TITLE
51 画像を3枚投稿した時の挙動を修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -86,6 +86,9 @@ gem 'fog-aws'
 # ページネーション
 gem 'kaminari'
 
+#バックグラウンド処理
+gem 'sidekiq'
+
 # その他
 gem 'redis-rails'
 gem 'puma_worker_killer'

--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ gem 'devise-i18n-views'
 
 #画像アップロード
 gem 'carrierwave', '~> 3.0'
+gem 'carrierwave_backgrounder'
 gem "aws-sdk-s3", require: false
 gem 'fog-aws'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,9 @@ GEM
       image_processing (~> 1.1)
       marcel (~> 1.0.0)
       ssrf_filter (~> 1.0)
+    carrierwave_backgrounder (1.0.2)
+      carrierwave (> 2.0, < 4.0)
+      rails (> 6.0, < 8.0)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
@@ -424,6 +427,7 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap
   carrierwave (~> 3.0)
+  carrierwave_backgrounder
   cssbundling-rails
   debug
   devise

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,7 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    logger (1.6.0)
     loofah (2.22.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
@@ -370,6 +371,12 @@ GEM
       railties (>= 5.2)
     ruby-vips (2.2.1)
       ffi (~> 1.12)
+    sidekiq (7.3.0)
+      concurrent-ruby (< 2)
+      connection_pool (>= 2.3.0)
+      logger
+      rack (>= 2.2.4)
+      redis-client (>= 0.22.2)
     snaky_hash (2.0.1)
       hashie
       version_gem (~> 1.1, >= 1.1.1)
@@ -446,6 +453,7 @@ DEPENDENCIES
   rails-i18n (~> 7.0.0)
   ransack
   redis-rails
+  sidekiq
   sprockets-rails
   stackprof
   stimulus-rails

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -21,6 +21,12 @@ class ReviewsController < ApplicationController
     if @review.save
       reviews_data
       @review.save_tags(tag_list)
+
+      # 画像アップロードを非同期に行う
+      @review.images.each do |image|
+        ImageUploadJob.perform_later(image)
+      end
+      
       flash.now[:success] = "口コミを投稿しました"
       render turbo_stream: [
         turbo_stream.prepend("reviews", partial: "reviews/review", locals: { review: @review }),

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -21,11 +21,6 @@ class ReviewsController < ApplicationController
     if @review.save
       reviews_data
       @review.save_tags(tag_list)
-
-      # 画像アップロードを非同期に行う
-      @review.images.each do |image|
-        ImageUploadJob.perform_later(image)
-      end
       
       flash.now[:success] = "口コミを投稿しました"
       render turbo_stream: [

--- a/app/jobs/image_upload_job.rb
+++ b/app/jobs/image_upload_job.rb
@@ -1,8 +1,0 @@
-class ImageUploadJob < ApplicationJob
-    queue_as :default
-
-    def perform(image)
-        uploader = ImageUploader.new
-        uploader.store!(image)
-    end
-end

--- a/app/jobs/image_upload_job.rb
+++ b/app/jobs/image_upload_job.rb
@@ -1,0 +1,8 @@
+class ImageUploadJob < ApplicationJob
+    queue_as :default
+
+    def perform(image)
+        uploader = ImageUploader.new
+        uploader.store!(image)
+    end
+end

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -6,6 +6,8 @@ class Review < ApplicationRecord
   has_many :tags, through: :review_tags
   attr_accessor :images_cache
   mount_uploaders :images, ImageUploader
+  process_in_background :images
+
 
   validates :rating, presence: true, numericality: { in: 1..5, message: "を入力してください" }
   validates :body, length: { maximum: 400 }

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -2,6 +2,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Include RMagick or MiniMagick support:
   # include CarrierWave::RMagick
   include CarrierWave::MiniMagick
+  include ::CarrierWave::Backgrounder::Delay
 
   # Choose what kind of storage to use for this uploader:
   if Rails.env.production?

--- a/app/views/spots/map.html.erb
+++ b/app/views/spots/map.html.erb
@@ -1,5 +1,5 @@
 <% content_for(:title, t('spots.map.title')) %>
-<div class="hidden md:block md:ml-64 md:mt-3">
+<div class="hidden md:block md:ml-64 md:mt-4">
   <%= render 'layouts/flash_messages', flash: flash %>
 </div>
 <div class="md:flex <%= 'md:mt-16' unless flash.any? %>">

--- a/compose.yml
+++ b/compose.yml
@@ -31,6 +31,14 @@ services:
     command: redis-server --appendonly yes
     ports:
       - "6379:6379"
+  sidekiq:
+    build: .
+    command: bundle exec sidekiq
+    volumes:
+      - .:/app
+    depends_on:
+      - db
+      - redis
 volumes:
   postgres_data:
   bundle_data:

--- a/config/application.rb
+++ b/config/application.rb
@@ -30,6 +30,7 @@ module App
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
     config.paths.add "lib", eager_load: true
+    config.active_job.queue_adapter = :sidekiq
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/config/initializers/carrierwave_backgrounder.rb
+++ b/config/initializers/carrierwave_backgrounder.rb
@@ -1,0 +1,4 @@
+CarrierWave::Backgrounder.configure do |c|
+  #c.backend :active_job, queue: :carrierwave
+  c.backend :sidekiq, queue: :carrierwave
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+    config.redis = { url: 'redis://redis:6379' }
+end
+
+Sidekiq.configure_client do |config|
+    config.redis = { url: 'redis://redis:6379' }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,10 @@
+require 'sidekiq/web'
+
 Rails.application.routes.draw do
+  Sidekiq::Web.use(Rack::Auth::Basic) do |user_id, password|
+    [user_id, password] == [ENV['SIDEKIQ_BASIC_ID'], ENV['SIDEKIQ_BASIC_PASSWORD']]
+  end
+  mount Sidekiq::Web, at: '/sidekiq'
   get 'rewiews/new'
   get 'rewiews/create'
   get 'users/show'

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,2 @@
+:queues:
+  - default

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,3 @@
 :queues:
   - default
+  - carrierwave


### PR DESCRIPTION
# 概要
## レビューにて複数画像投稿時のパフォーマンス改善（本番環境で動作確認）
- [x] sidekiqによるバックグラウンド処理で画像のアップロードを非同期化
- [x] `gem 'sidekiq'`と`gem 'carrierwave_backgrounder'`を導入
- [x] ターミナルのログにて正常に処理が完了していることを確認`sidekiq-1  | 2024-07-06T17:37:52.140Z pid=1 tid=gap class=CarrierWave::Workers::ProcessAsset jid=700ba14dacf2af0685d54709 elapsed=3.539 INFO: done`