### PR TITLE
231 スポット詳細の動的ogp

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,9 @@ gem 'kaminari'
 #バックグラウンド処理
 gem 'sidekiq'
 
+gem 'faraday'
+gem 'faraday-follow_redirects'
+
 # その他
 gem 'redis-rails'
 gem 'puma_worker_killer'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,6 +139,8 @@ GEM
     excon (0.110.0)
     faraday (2.9.0)
       faraday-net_http (>= 2.0, < 3.2)
+    faraday-follow_redirects (0.3.0)
+      faraday (>= 1, < 3)
     faraday-net_http (3.1.0)
       net-http
     ffi (1.16.3)
@@ -433,6 +435,8 @@ DEPENDENCIES
   devise
   devise-i18n-views
   dotenv-rails
+  faraday
+  faraday-follow_redirects
   flamegraph
   fog-aws
   geocoder

--- a/app/controllers/spot_images_controller.rb
+++ b/app/controllers/spot_images_controller.rb
@@ -1,0 +1,27 @@
+class SpotImagesController < ApplicationController
+    def show
+        photo_reference = params[:photo_reference]
+        api_key = ENV['GMAP_API_KEY']
+        url = "https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&photo_reference=#{photo_reference}&key=#{api_key}"
+    
+        conn = Faraday.new do |f|
+        f.response :follow_redirects
+        f.adapter Faraday.default_adapter
+        end
+    
+        begin
+        response = conn.get(url)
+    
+        if response.status == 302 || response.status == 200
+            location = response.headers['location'] || url
+            redirect_to location, allow_other_host: true
+        else
+            Rails.logger.error "Image not found for URL: #{url}, Response status: #{response.status}"
+            render plain: 'Image not found', status: :not_found
+        end
+        rescue => e
+        Rails.logger.error "Failed to load image: #{e.message}"
+        render plain: 'Internal Server Error', status: :internal_server_error
+        end
+    end
+end

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -5,6 +5,9 @@ const application = Application.start()
 import { Tabs } from "tailwindcss-stimulus-components"
 application.register('tabs', Tabs)
 
+import { Toggle } from "tailwindcss-stimulus-components"
+application.register('toggle', Toggle)
+
 import { Autocomplete } from 'stimulus-autocomplete'
 application.register('autocomplete', Autocomplete)
 

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -35,6 +35,14 @@ export default class extends Controller {
         }
       }
     });
+
+    // 検索ボタンが押された時もオーバーレイを閉じる
+    this.drawer.querySelectorAll('form').forEach(form => {
+      form.addEventListener('submit', () => {
+        this.drawer.classList.add('translate-y-full');
+        this.hideBackdrop();
+      });
+    });
   }
 
   showBackdrop() {

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -1,0 +1,41 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="drawer"
+export default class extends Controller {
+  static targets = ["drawer"];
+
+  connect() {
+    this.drawer = document.getElementById('drawer-swipe');
+    document.querySelectorAll('[data-drawer-show]').forEach(button => {
+      button.addEventListener('click', () => {
+        this.showBackdrop();
+      });
+    });
+    this.drawer.querySelector('[data-drawer-toggle]').addEventListener('click', () => {
+      this.hideBackdrop();
+    });
+  }
+
+  showBackdrop() {
+    this.createBackdrop();
+  }
+
+  hideBackdrop() {
+    this.removeBackdrop();
+  }
+
+  createBackdrop() {
+    if (!this.backdrop) {
+      this.backdrop = document.createElement('div');
+      this.backdrop.className = 'fixed inset-0 bg-black bg-opacity-50 z-30';
+      document.body.appendChild(this.backdrop);
+    }
+  }
+
+  removeBackdrop() {
+    if (this.backdrop) {
+      document.body.removeChild(this.backdrop);
+      this.backdrop = null;
+    }
+  }
+}

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -14,6 +14,27 @@ export default class extends Controller {
     this.drawer.querySelector('[data-drawer-toggle]').addEventListener('click', () => {
       this.hideBackdrop();
     });
+
+    // Drawer open events
+    this.drawer.addEventListener('show.bs.drawer', () => {
+      this.showBackdrop();
+    });
+
+    // Drawer close events
+    this.drawer.addEventListener('hidden.bs.drawer', () => {
+      this.hideBackdrop();
+    });
+
+    // Handling swipe or any other transition that triggers open/close
+    this.drawer.addEventListener('transitionend', (event) => {
+      if (event.propertyName === 'transform') {
+        if (this.drawer.classList.contains('translate-y-full')) {
+          this.hideBackdrop();
+        } else {
+          this.showBackdrop();
+        }
+      }
+    });
   }
 
   showBackdrop() {
@@ -29,6 +50,12 @@ export default class extends Controller {
       this.backdrop = document.createElement('div');
       this.backdrop.className = 'fixed inset-0 bg-black bg-opacity-50 z-30';
       document.body.appendChild(this.backdrop);
+
+      // Add event listener to close the drawer when the backdrop is clicked
+      this.backdrop.addEventListener('click', () => {
+        this.drawer.classList.add('translate-y-full');
+        this.hideBackdrop();
+      });
     }
   }
 

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -5,30 +5,39 @@ export default class extends Controller {
   static targets = ["drawer"];
 
   connect() {
-    this.drawer = document.getElementById('drawer-swipe');
-    document.querySelectorAll('[data-drawer-show]').forEach(button => {
+    this.initializeDrawer('drawer-swipe');
+    this.initializeDrawer('review-drawer-swipe');
+    this.initializeDrawer('no-review-drawer-swipe');
+  }
+
+  initializeDrawer(drawerId) {
+    const drawer = document.getElementById(drawerId);
+    if (!drawer) return;
+
+    document.querySelectorAll(`[data-drawer-show="${drawerId}"]`).forEach(button => {
       button.addEventListener('click', () => {
         this.showBackdrop();
       });
     });
-    this.drawer.querySelector('[data-drawer-toggle]').addEventListener('click', () => {
+
+    drawer.querySelector('[data-drawer-toggle]').addEventListener('click', () => {
       this.hideBackdrop();
     });
 
     // Drawer open events
-    this.drawer.addEventListener('show.bs.drawer', () => {
+    drawer.addEventListener('show.bs.drawer', () => {
       this.showBackdrop();
     });
 
     // Drawer close events
-    this.drawer.addEventListener('hidden.bs.drawer', () => {
+    drawer.addEventListener('hidden.bs.drawer', () => {
       this.hideBackdrop();
     });
 
     // Handling swipe or any other transition that triggers open/close
-    this.drawer.addEventListener('transitionend', (event) => {
+    drawer.addEventListener('transitionend', (event) => {
       if (event.propertyName === 'transform') {
-        if (this.drawer.classList.contains('translate-y-full')) {
+        if (drawer.classList.contains('translate-y-full')) {
           this.hideBackdrop();
         } else {
           this.showBackdrop();
@@ -36,10 +45,10 @@ export default class extends Controller {
       }
     });
 
-    // 検索ボタンが押された時もオーバーレイを閉じる
-    this.drawer.querySelectorAll('form').forEach(form => {
+    // Handle form submission within the drawer
+    drawer.querySelectorAll('form').forEach(form => {
       form.addEventListener('submit', () => {
-        this.drawer.classList.add('translate-y-full');
+        drawer.classList.add('translate-y-full');
         this.hideBackdrop();
       });
     });
@@ -61,7 +70,9 @@ export default class extends Controller {
 
       // Add event listener to close the drawer when the backdrop is clicked
       this.backdrop.addEventListener('click', () => {
-        this.drawer.classList.add('translate-y-full');
+        document.querySelectorAll('.drawer.open').forEach(drawer => {
+          drawer.classList.add('translate-y-full');
+        });
         this.hideBackdrop();
       });
     }

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -4,11 +4,17 @@
 
 import { application } from "./application"
 
+import Dropdown from '@stimulus-components/dropdown'
+application.register('dropdown', Dropdown)
+
 import AccordionController from "./accordion_controller"
 application.register("accordion", AccordionController)
 
 import DiagnosticController from "./diagnostic_controller"
 application.register("diagnostic", DiagnosticController)
+
+import DrawerController from "./drawer_controller"
+application.register("drawer", DrawerController)
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)

--- a/app/javascript/gmap.js
+++ b/app/javascript/gmap.js
@@ -284,12 +284,7 @@ function updateInfoCard(spot) {
   var infoCard = document.getElementById(infoCardId);
   if (infoCard) {
     infoCard.classList.remove('hidden');
-    let imageUrl;
-    if (!spot.image || spot.image === 'default.png') {
-      imageUrl = window.defaultImagePath; // デフォルト画像のURL
-    } else {
-      imageUrl = `https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=${spot.image}&key=${apiKey}`;
-    }
+    let imageUrl = window.prioritizedImageUrls[spot.id] || window.defaultImagePath;
     infoCard.querySelector(`#spotImage-${spot.id}`).src = imageUrl;
     infoCard.querySelector(`#spotName-${spot.id}`).textContent = spot.name;
     infoCard.querySelector(`#spotRating-${spot.id}`).textContent = `⭐️ ${spot.rating !== null && spot.rating !== undefined ? spot.rating : '評価なし'}`;
@@ -398,12 +393,7 @@ function updateSpotsList(categoryId) {
         frame.innerHTML = '';  // Frame の内容をクリア
 
         data.forEach(spot => {
-          let imageUrl;
-          if (!spot.image || spot.image === 'default.png') {
-            imageUrl = window.defaultImagePath; // デフォルト画像のURL
-          } else {
-            imageUrl = `https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=${spot.image}&key=${apiKey}`;
-          }
+          let imageUrl = window.prioritizedImageUrls[spot.id] || window.defaultImagePath;
             const spotElement = document.createElement('div');
             spotElement.className = 'spot-item';
             spotElement.innerHTML = `

--- a/app/models/spot.rb
+++ b/app/models/spot.rb
@@ -40,9 +40,7 @@ class Spot < ApplicationRecord
     %i[with_tag]
   end
 
-  scope :sorted_by_rating, -> { order(rating: :desc) }
-  scope :sorted_by_created_at_asc, -> { order(created_at: :asc) }
-  scope :sorted_by_created_at_desc, -> { order(created_at: :desc) }
+
 
   # 猫の画像を優先的に表示させるメソッド
   def prioritized_spot_image #SpotImageの中で、cat属性がtrueのものを優先的に取得し、存在しない場合は最初のSpotImageを取得する

--- a/app/views/diagnostics/_spot.html.erb
+++ b/app/views/diagnostics/_spot.html.erb
@@ -3,7 +3,7 @@
         <%= link_to spot_path(@recommend_spot), data: { turbo: false } do %>
             <% prioritized_image = @recommend_spot.prioritized_spot_image %>
             <% if prioritized_image.present? %>
-                <img src="https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=<%= prioritized_image.image %>&key=<%= ENV['GMAP_API_KEY'] %>" class="w-full h-full absolute rounded-l-xl md:rounded-t-xl md:rounded-b-none top-0 left-0 md:left-none object-cover transition-transform duration-200 ease-in-out group-hover:scale-110 group-hover:rounded-xl" alt="Image Description">
+                <%= image_tag spot_image_proxy_url(prioritized_image.image), class: "w-full h-full absolute rounded-l-xl md:rounded-t-xl md:rounded-b-none top-0 left-0 md:left-none object-cover transition-transform duration-200 ease-in-out group-hover:scale-110 group-hover:rounded-xl", alt: "Image Description" %>
             <% else %>
                 <% image_tag('default.png', class: "h-full absolute rounded-l-xl md:rounded-t-xl md:rounded-b-none top-0 left-1/2 transform -translate-x-1/2 md:left-none object-cover transition-transform duration-200 ease-in-out group-hover:scale-110 group-hover:rounded-xl")%>
             <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -98,6 +98,7 @@
   </div>
     <%= yield %>
     <%= render "shared/footer" %>
+    <script src="https://cdn.jsdelivr.net/npm/flowbite@2.4.1/dist/flowbite.turbo.min.js"></script>
     <script src="https://cdn.jsdelivr.net/combine/npm/jquery@1.11,npm/midnight.js@1.1"></script>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js"></script>
     <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>

--- a/app/views/reviews/_review.html.erb
+++ b/app/views/reviews/_review.html.erb
@@ -68,7 +68,7 @@
                 <% end %>
             <% end %>
             <div>
-                <%= link_to "https://twitter.com/share?url=https://nekospot.jp/spots/#{review.spot.id}/reviews/#{review.id}&text=#{ERB::Util.url_encode("「#{review.spot.name}」の口コミを投稿しました🐈✨\n ##{review.spot.name.gsub(/[\s()（）【】]/, '')} #NekoSpot \n")}", target: '_blank', class: "relative rounded px-3 py-2.5 overflow-hidden group bg-neutral relative hover:bg-gradient-to-r hover:from-neutral hover:to-secondary text-white hover:ring-2 hover:ring-offset-2 hover:ring-secondary transition-all ease-out duration-300" do %>
+                <%= link_to "https://twitter.com/share?url=https://nekospot.jp/spots/#{review.spot.id}/reviews/#{review.id}&text=#{ERB::Util.url_encode("「#{review.spot.name}」の口コミを投稿しました🐈✨\n ##{review.spot.name.gsub(/[\s()（）【】]/, '')} #NekoSpot \n")}", target: '_blank', class: "relative rounded md:px-3 py-2.5 px-2 overflow-hidden group bg-neutral relative hover:bg-gradient-to-r hover:from-neutral hover:to-secondary text-white hover:ring-2 hover:ring-offset-2 hover:ring-secondary transition-all ease-out duration-300" do %>
                         <span class="absolute right-0 w-8 h-32 -mt-12 transition-all duration-1000 transform translate-x-12 bg-white opacity-10 rotate-12 group-hover:-translate-x-40 ease"></span>
                         <span class="relative text-sm text-white dark:text-gray-400 "><i class="ph-bold ph-x-logo fa-lg w-6 h-3" aria-hidden="true"></i>シェア</span>
                 <% end %>

--- a/app/views/spots/_index_spot_search.html.erb
+++ b/app/views/spots/_index_spot_search.html.erb
@@ -1,0 +1,54 @@
+<div data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
+    <%= search_form_for @q_spots, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto px-8 pb-16 md:px-4 md:py-4", data: { turbo_frame: "spots-list" } }  do |f| %>
+        <label for="" class="mb-2 text-sm font-medium text-secondary sr-only dark:text-white">検索</label>
+        <div class="relative">
+            <div class="absolute inset-y-4 md:inset-y-3 start-0 flexed items-center ps-3 pointer-events-none">
+                <i class="ph ph-magnifying-glass text-secondary"></i>
+            </div>
+            <%= f.search_field :name_or_address_cont, data: { autocomplete_target: 'input' }, class: 'block w-full p-4 md:p-3 ps-10 md:ps-8 text-sm text-secondary border border-secondary rounded-full bg-white focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
+            <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
+            <%= f.hidden_field :address, data: { autocomplete_target: 'hidden' } %>
+            <ul class="list-group absolute w-full bg-white p-2 shadow z-[1] rounded-box" data-autocomplete-target="results"></ul>
+        </div>
+        <div class="space-x-2 md:my-4 mt-8 mb-4">
+            <div class="my-1 inline-flex text-secondary text-xs rounded-lg py-1 px-1.5 bg-primary items-center hover:bg-primary-hover">
+                <%= f.radio_button :with_tag, '', id: "tag_none", checked: true %>
+                <%= f.label :with_tag, "指定なし", value: '', id: "tag_none" %>
+            </div>
+            <% @tags.each do |tag| %>
+                <div class="my-1 group inline-flex text-secondary text-xs rounded-lg py-1 px-1.5 bg-primary items-center hover:bg-primary-hover">
+                    <%= f.radio_button :with_tag, tag.name, id: "tag_#{tag.id}" %>
+                    <i class="ph ph-tag"></i>&nbsp;<%= f.label :with_tag, tag.name, "tag_#{tag.id}" %>
+                </div>
+            <% end %>
+        </div>
+        <div class="text-secondary flex-col items-center md:space-y-4">
+            <div class="flex space-x-4 md:space-x-0 md:flex-col pt-4 pl-2 mb-4 md:mb-0">
+                <div class='label-select flex h-full text-sm space-x-2 items-center'>
+                    <%= f.check_box :foster_parents_eq, { include_hidden: false, class: 'search-select text-sm checkbox checkbox-sm checkbox-secondary [--chkbg:theme(colors.secondary)] [--chkfg:white]' }, 1, nil %>
+                    <%= f.label :foster_parents_eq, '里親募集あり', class: 'label text-sm font-semibold' %>
+                </div>
+                <div class='label-select flex h-full text-sm space-x-2 items-center'>
+                    <%= f.check_box :adoption_event_eq, { include_hidden: false, class: 'search-select text-sm checkbox checkbox-sm checkbox-secondary [--chkbg:theme(colors.secondary)] [--chkfg:white]' }, 1, nil %>
+                    <%= f.label :adoption_event_eq, '譲渡会開催あり', class: 'label text-sm font-semibold' %>
+                </div>
+            </div>
+            <div class="flex md:flex-col md:space-y-3 md:space-x-0 space-x-4 mb-4 md:mb-0">
+                <div class='label-select h-full md:w-full w-1/2 text-sm'>
+                    <%= f.label :category_id_eq, 'カテゴリ', class: 'label text-sm font-semibold' %>
+                    <%= f.collection_select :category_id_eq, @categories, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
+                </div>
+                <div class='label-select h-full md:w-full w-1/2 text-sm md:mb-8'>
+                    <%= f.label :prefecture_id_eq, '都道府県', class: 'label text-sm font-semibold' %>
+                    <%= f.collection_select :prefecture_id_eq, @prefectures, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
+                </div>
+            </div>
+            <div class="flex justify-center items-center md:mt-12 mt-8 mb-4">
+                <%= f.submit 'この条件で検索する', class: 'font-semibold text-sm rounded-md relative inline-flex group items-center justify-center px-3.5 py-2 m-1 cursor-pointer border-b-4 border-l-2 active:border-accent active:shadow-none shadow-lg bg-gradient-to-tr from-accent to-accent-active border-accent-hover text-white' do %>
+                    <span class="absolute w-0 h-0 transition-all duration-300 ease-out bg-white rounded-full group-hover:w-32 group-hover:h-32 opacity-10"></span>
+                    <span class="relative"></span>
+                <% end %>
+            </div>
+        </div>
+    <% end %>
+</div>

--- a/app/views/spots/_no_review_drawer_swipe.html.erb
+++ b/app/views/spots/_no_review_drawer_swipe.html.erb
@@ -1,0 +1,38 @@
+<div id="no-review-drawer-swipe" class="md:hidden fixed z-40 w-full overflow-y-auto bg-white border-t border-gray-200 rounded-t-lg dark:border-gray-700 dark:bg-gray-800 transition-transform bottom-0 left-0 right-0 translate-y-full bottom-[60px]" tabindex="-1" aria-labelledby="drawer-swipe-label">
+    <div class="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700" data-drawer-toggle="no-review-drawer-swipe">
+        <span class="absolute w-8 h-1 -translate-x-1/2 bg-gray-300 rounded-lg top-3 left-1/2 dark:bg-gray-600"></span>
+        <h5 id="drawer-swipe-label" class="inline-flex items-center text-base text-gray-500 dark:text-gray-400 font-medium">
+        <i class="ph-bold ph-list-magnifying-glass fa-2xl text-primary-hover"></i>&ensp;絞り込み</h5>
+    </div>
+    <div data-controller="autocomplete" data-autocomplete-url-value="/reviews/search" role="combobox">
+        <%= search_form_for @q_reviews, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto py-4 px-8", data: { turbo_frame: "reviews-list" } }  do |f| %>
+            <label for="" class="mb-2 text-sm font-medium text-secondary sr-only dark:text-white">検索</label>
+            <div class="relative">
+                <div class="absolute inset-y-4 md:inset-y-3 start-0 flexed items-center ps-3 pointer-events-none">
+                    <i class="ph ph-magnifying-glass text-secondary"></i>
+                </div>
+                <%= f.search_field :spot_name_or_spot_address_or_body_cont, data: { autocomplete_target: 'input' }, class: 'block w-full p-4 md:p-3 ps-10 md:ps-8 text-sm text-secondary border border-secondary rounded-full bg-white focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
+                <%= f.hidden_field :spot_name, data: { autocomplete_target: 'hidden' } %>
+                <%= f.hidden_field :spot_address, data: { autocomplete_target: 'hidden' } %>
+                <%= f.hidden_field :body, data: { autocomplete_target: 'hidden' } %>
+                <ul class="list-group absolute w-full bg-white p-2 shadow z-[1] rounded-box" data-autocomplete-target="results"></ul>
+            </div>
+            <div class="flex md:flex-col md:space-y-3 md:space-x-0 space-x-4 mt-8 text-secondary">
+                <div class='label-select h-full md:w-full w-1/2 text-sm'>
+                    <%= f.label :spot_category_id_eq, 'カテゴリ', class: 'label text-sm font-semibold' %>
+                    <%= f.collection_select :spot_category_id_eq, @categories, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
+                </div>
+                <div class='label-select h-full md:w-full w-1/2 text-sm md:mb-8'>
+                    <%= f.label :spot_prefecture_id_eq, '都道府県', class: 'label text-sm font-semibold' %>
+                    <%= f.collection_select :spot_prefecture_id_eq, @prefectures, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
+                </div>
+            </div>
+            <div class="flex justify-center items-center mb-16 mt-8">
+                <%= f.submit 'この条件で検索する', class: 'font-semibold text-sm rounded-md relative inline-flex group items-center justify-center px-3.5 py-2 m-1 cursor-pointer border-b-4 border-l-2 active:border-accent active:shadow-none shadow-lg bg-gradient-to-tr from-accent to-accent-active border-accent-hover text-white' do %>
+                    <span class="absolute w-0 h-0 transition-all duration-300 ease-out bg-white rounded-full group-hover:w-32 group-hover:h-32 opacity-10"></span>
+                    <span class="relative"></span>
+                <% end %>
+            </div>
+        <% end %>
+    </div>
+</div>

--- a/app/views/spots/_review.html.erb
+++ b/app/views/spots/_review.html.erb
@@ -131,7 +131,7 @@
                 <% end %>
             </div>
             <div class="md:hidden">
-                <%= link_to "https://twitter.com/share?url=https://nekospot.jp/spots/#{review.spot.id}/reviews/#{review.id}&text=#{ERB::Util.url_encode("「#{review.spot.name}」の口コミを投稿しました🐈✨\n ##{review.spot.name.gsub(/[\s()（）【】]/, '')} #NekoSpot \n")}", target: '_blank', class: "relative rounded px-3 py-2.5 overflow-hidden group bg-neutral relative hover:bg-gradient-to-r hover:from-neutral hover:to-secondary text-white hover:ring-2 hover:ring-offset-2 hover:ring-secondary transition-all ease-out duration-300" do %>
+                <%= link_to "https://twitter.com/share?url=https://nekospot.jp/spots/#{review.spot.id}/reviews/#{review.id}&text=#{ERB::Util.url_encode("「#{review.spot.name}」の口コミを投稿しました🐈✨\n ##{review.spot.name.gsub(/[\s()（）【】]/, '')} #NekoSpot \n")}", target: '_blank', class: "relative rounded px-2 py-2.5 overflow-hidden group bg-neutral relative hover:bg-gradient-to-r hover:from-neutral hover:to-secondary text-white hover:ring-2 hover:ring-offset-2 hover:ring-secondary transition-all ease-out duration-300" do %>
                         <span class="absolute right-0 w-8 h-32 -mt-12 transition-all duration-1000 transform translate-x-12 bg-white opacity-10 rotate-12 group-hover:-translate-x-40 ease"></span>
                         <span class="relative text-sm text-white dark:text-gray-400 "><i class="ph-bold ph-x-logo fa-lg w-6 h-3" aria-hidden="true"></i>シェア</span>
                 <% end %>

--- a/app/views/spots/_review_drawer_swipe.html.erb
+++ b/app/views/spots/_review_drawer_swipe.html.erb
@@ -1,0 +1,38 @@
+<div id="review-drawer-swipe" class="md:hidden fixed z-40 w-full overflow-y-auto bg-white border-t border-gray-200 rounded-t-lg dark:border-gray-700 dark:bg-gray-800 transition-transform bottom-0 left-0 right-0 translate-y-full bottom-[60px]" tabindex="-1" aria-labelledby="drawer-swipe-label">
+    <div class="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700" data-drawer-toggle="review-drawer-swipe">
+        <span class="absolute w-8 h-1 -translate-x-1/2 bg-gray-300 rounded-lg top-3 left-1/2 dark:bg-gray-600"></span>
+        <h5 id="drawer-swipe-label" class="inline-flex items-center text-base text-gray-500 dark:text-gray-400 font-medium">
+        <i class="ph-bold ph-list-magnifying-glass fa-2xl text-primary-hover"></i>&ensp;絞り込み</h5>
+    </div>
+    <div data-controller="autocomplete" data-autocomplete-url-value="/reviews/search" role="combobox">
+        <%= search_form_for @q_reviews, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto py-4 px-8", data: { turbo_frame: "reviews-list" } }  do |f| %>
+            <label for="" class="mb-2 text-sm font-medium text-secondary sr-only dark:text-white">検索</label>
+            <div class="relative">
+                <div class="absolute inset-y-4 md:inset-y-3 start-0 flexed items-center ps-3 pointer-events-none">
+                    <i class="ph ph-magnifying-glass text-secondary"></i>
+                </div>
+                <%= f.search_field :spot_name_or_spot_address_or_body_cont, data: { autocomplete_target: 'input' }, class: 'block w-full p-4 md:p-3 ps-10 md:ps-8 text-sm text-secondary border border-secondary rounded-full bg-white focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
+                <%= f.hidden_field :spot_name, data: { autocomplete_target: 'hidden' } %>
+                <%= f.hidden_field :spot_address, data: { autocomplete_target: 'hidden' } %>
+                <%= f.hidden_field :body, data: { autocomplete_target: 'hidden' } %>
+                <ul class="list-group absolute w-full bg-white p-2 shadow z-[1] rounded-box" data-autocomplete-target="results"></ul>
+            </div>
+            <div class="flex md:flex-col md:space-y-3 md:space-x-0 space-x-4 mt-8 text-secondary">
+                <div class='label-select h-full md:w-full w-1/2 text-sm'>
+                    <%= f.label :spot_category_id_eq, 'カテゴリ', class: 'label text-sm font-semibold' %>
+                    <%= f.collection_select :spot_category_id_eq, @categories, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
+                </div>
+                <div class='label-select h-full md:w-full w-1/2 text-sm md:mb-8'>
+                    <%= f.label :spot_prefecture_id_eq, '都道府県', class: 'label text-sm font-semibold' %>
+                    <%= f.collection_select :spot_prefecture_id_eq, @prefectures, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
+                </div>
+            </div>
+            <div class="flex justify-center items-center mb-16 mt-8">
+                <%= f.submit 'この条件で検索する', class: 'font-semibold text-sm rounded-md relative inline-flex group items-center justify-center px-3.5 py-2 m-1 cursor-pointer border-b-4 border-l-2 active:border-accent active:shadow-none shadow-lg bg-gradient-to-tr from-accent to-accent-active border-accent-hover text-white' do %>
+                    <span class="absolute w-0 h-0 transition-all duration-300 ease-out bg-white rounded-full group-hover:w-32 group-hover:h-32 opacity-10"></span>
+                    <span class="relative"></span>
+                <% end %>
+            </div>
+        <% end %>
+    </div>
+</div>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -3,7 +3,7 @@
         <%= link_to spot_path(spot), data: { turbo: false } do %>
             <% prioritized_image = spot.prioritized_spot_image %>
             <% if prioritized_image.present? %>
-                <img src="https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&maxwidth=1000&photo_reference=<%= prioritized_image.image %>&key=<%= ENV['GMAP_API_KEY'] %>" class="w-full h-full absolute rounded-t-xl md:rounded-b-none top-0 left-0 md:left-none object-cover transition-transform duration-200 ease-in-out group-hover:scale-110 group-hover:rounded-xl" alt="Image Description">
+                <%= image_tag spot_image_proxy_url(prioritized_image.image), class: "w-full h-full absolute rounded-t-xl md:rounded-b-none top-0 left-0 md:left-none object-cover transition-transform duration-200 ease-in-out group-hover:scale-110 group-hover:rounded-xl", alt: "Image Description" %>
             <% else %>
                 <% image_tag('default.webp', class: "h-full absolute rounded-t-xl rounded-b-none top-0 left-1/2 transform -translate-x-1/2 md:left-none object-cover transition-transform duration-200 ease-in-out group-hover:scale-110 group-hover:rounded-xl")%>
             <% end %>

--- a/app/views/spots/_spot.html.erb
+++ b/app/views/spots/_spot.html.erb
@@ -12,7 +12,7 @@
     <div class="flex flex-wrap w-full md:h-full h-28">
         <div class="p-2 md:p-2.5 flex flex-col h-full sm:p-7 w-full relative">
             <div class="bg-accent absolute top-0 -mt-3 flex items-center font-semibold px-3 py-1.5 leading-none w-auto rounded-full text-xs uppercase text-white">
-                <span><i class="ph-fill ph-star fa-lg"></i> <%= spot.rating || '評価なし' %></span>
+                <span><i class="ph-fill ph-star fa-lg"></i> <%= spot.rating.nil? ? '評価なし' : spot.rating %></span>
             </div>
             <p class="md:px-1.5 mt-2 text-[10px] text-secondary dark:text-neutral-500"><%= spot.category.name %> / <%= formatted_address(spot.address) %></p>
             <%= link_to spot_path(spot), data: { turbo: false } do %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -137,7 +137,7 @@
                         <div class="grid md:grid-cols-4">
                             <div class="md:col-span-1 md:p-4 md:mt-12">
                                 <div data-controller="autocomplete" data-autocomplete-url-value="/reviews/search" role="combobox">
-                                    <%= search_form_for @q_reviews, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto py-8 md:py-4", data: { turbo_frame: "reviews-list" } }  do |f| %>
+                                    <%= search_form_for @q_reviews, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto py-8 md:py-4 hidden md:block", data: { turbo_frame: "reviews-list" } }  do |f| %>
                                         <label for="" class="mb-2 text-sm font-medium text-secondary sr-only dark:text-white">検索</label>
                                         <div class="relative">
                                             <div class="absolute inset-y-4 md:inset-y-3 start-0 flexed items-center ps-3 pointer-events-none">
@@ -167,7 +167,7 @@
                                             <% end %>
                                         </div>
                                     <% end %>
-                                    <div class="md:mt-8 mb-8 flex flex-row flex-wrap space-x-2 items-center space-y-2">
+                                    <div class="my-8 flex flex-row flex-wrap space-x-2 items-center space-y-2">
                                         <% if @tags.present? %>
                                             <div class="flex flex-col"><h2 class='text-secondary text-sm font-semibold'>タグ一覧</h2></div>
                                             <br>
@@ -195,9 +195,15 @@
                                         </form>
                                     </dialog>
                                 </div>
+
                                 <%= turbo_frame_tag "reviews-list" do %>
                                     <%= turbo_frame_tag 'tags_search' do %>
                                         <% if @reviews.present? %>
+                                            <button class="btn md:hidden fixed bottom-16 left-1/2 transform -translate-x-1/2 rounded-lg border-secondary bg-primary hover:bg-primary z-10" data-drawer-target="review-drawer-swipe" data-drawer-show="review-drawer-swipe" data-drawer-placement="bottom" data-drawer-edge="true" data-drawer-edge-offset="bottom-[60px]" data-drawer-backdrop="true" aria-controls="review-drawer-swipe">
+                                                <i class="ph-bold ph-list-magnifying-glass fa-2xl text-primary-hover"></i>
+                                                <span class="text-[12px] text-secondary dark:text-gray-400 group-hover:text-neutral">絞り込み</span>
+                                            </button>
+                                            <%= render "spots/review_drawer_swipe"%>
                                             <div class="pb-24 md:pb-16 md:pt-8 md:grid md:grid-cols-3 md:gap-8 md:pr-8 md:pl-4">
                                                 <% @reviews.each do |review| %>
                                                     <%= render 'spots/review', review: review, user: review.user %>
@@ -205,7 +211,18 @@
                                                 <%= paginate @reviews %>
                                             </div>
                                         <% else %>
-                                            <%= render 'spots/no_reviews' %>
+                                            <div class="">
+                                                <h2 class="my-3 text-xl font-zenmaru font-bold text-neutral border-bottom">口コミ一覧</h2>
+                                                <div class="mx-auto flex flex-col items-center justify-center w-3/5">
+                                                    <%= image_tag("936.webp", class: "h-full md:h-64 md:w-56 flex items-center justify-center") %>
+                                                    <h3 class="font-bold flex items-center justify-center w-full font-zenmaru text-neutral text-sm md:text-lg"> <i class="ph ph-empty fa-lg"></i>  まだ口コミがありません</h3>
+                                                    <button class="btn md:hidden mt-4 mb-24 flex justify-center rounded-lg border-secondary bg-primary hover:bg-primary z-10 w-48" data-drawer-target="no-review-drawer-swipe" data-drawer-show="no-review-drawer-swipe" data-drawer-placement="bottom" data-drawer-edge="true" data-drawer-edge-offset="bottom-[60px]" data-drawer-backdrop="true" aria-controls="no-review-drawer-swipe">
+                                                        <i class="ph-bold ph-list-magnifying-glass fa-2xl text-primary-hover"></i>
+                                                        <span class="text-[12px] text-secondary dark:text-gray-400 group-hover:text-neutral">絞り込み条件を変更</span>
+                                                    </button>
+                                                    <%= render "spots/no_review_drawer_swipe"%>
+                                                </div>
+                                            </div>
                                         <% end %>
                                     <% end %>
                                 <% end %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -66,7 +66,7 @@
                             </div>
                             <%= turbo_frame_tag "spots-list" do %>
                                 <div class="md:hidden" data-controller="dropdown">
-                                    <div class="join bg-primary fixed bottom-16 left-1/2 transform -translate-x-1/2 z-10" >
+                                    <div class="join bg-primary fixed bottom-16 left-1/5  transform -translate-x-1/5 z-10" >
                                         <button tabindex="0" class="btn join-item border-secondary" data-action="dropdown#toggle click@window->dropdown#hide">
                                             <i class="ph-bold ph-sort-descending fa-2xl text-primary-hover"></i>
                                             <span class="text-[12px] text-secondary dark:text-gray-400 group-hover:text-neutral">並び替え</span>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -39,7 +39,7 @@
             <div id="details-tab" class="hidden bg-white py-4 px-4 w-full h-full mb-12 md:mb-0 border-l border-b border-r rounded-b-lg rounded-r-lg" data-tabs-target="panel">
                 <div class="w-full mx-auto md:h-full pb-8 ">
                     <div class="grid md:grid-cols-4">
-                        <div class="md:col-span-1 md:p-4 md:mt-12">
+                        <div class="md:block md:col-span-1 md:p-4 md:mt-12 hidden">
                             <div data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
                                 <%= search_form_for @q_spots, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto py-8 md:py-4", data: { turbo_frame: "spots-list" } }  do |f| %>
                                     <label for="" class="mb-2 text-sm font-medium text-secondary sr-only dark:text-white">検索</label>
@@ -97,7 +97,7 @@
                             </div>
                         </div>
                         <div class="md:col-span-3">
-                            <div class="flex justify-end items-center">
+                            <div class="flex justify-end items-center" data-controller="drawer">
                                 <div class="dropdown dropdown-end">
                                     <div tabindex="0" role="button" class="hidden md:btn m-1 bg-white border-none md:rounded-full items-center shadow-lg">
                                         <i class="ph-bold ph-sort-descending fa-2xl text-primary-hover"></i>
@@ -119,17 +119,91 @@
                                 </dialog>
                             </div>
                             <%= turbo_frame_tag "spots-list" do %>
-                                <div class="flex justify-end items-center mb-8 md:hidden">
-                                    <div class="dropdown dropdown-end">
-                                        <div tabindex="0" role="button" class="btn bg-white border-none md:rounded-full items-center shadow-lg">
+                                <div class="md:hidden" data-controller="dropdown">
+                                    <div class="join bg-primary fixed bottom-16 left-1/2 transform -translate-x-1/2 z-10" >
+                                        <button tabindex="0" class="btn join-item border-secondary" data-action="dropdown#toggle click@window->dropdown#hide">
                                             <i class="ph-bold ph-sort-descending fa-2xl text-primary-hover"></i>
                                             <span class="text-[12px] text-secondary dark:text-gray-400 group-hover:text-neutral">並び替え</span>
-                                        </div>
-                                        <ul tabindex="0" class="dropdown-content menu bg-white rounded-box z-[1] w-52 p-2 shadow-lg text-neutral">
-                                            <li><li><%= sort_link(@q_spots, 'rating', '高評価', { default_order: :desc }) %></li></li>
-                                            <li><%= sort_link(@q_spots, 'created_at desc', '新着順', { default_order: :desc }) %></li>
-                                            <li><%= sort_link(@q_spots, 'created_at asc', '古い順', { default_order: :asc }) %></li>
-                                        </ul>
+                                        </button>
+                                        <button class="btn join-item rounded-r-lg border-secondary bg-primary hover:bg-primary" data-drawer-target="drawer-swipe" data-drawer-show="drawer-swipe" data-drawer-placement="bottom" data-drawer-edge="true" data-drawer-edge-offset="bottom-[60px]" data-drawer-backdrop="true" aria-controls="drawer-swipe">
+                                            <i class="ph-bold ph-list-magnifying-glass fa-2xl text-primary-hover"></i>
+                                            <span class="text-[12px] text-secondary dark:text-gray-400 group-hover:text-neutral">絞り込み</span>
+                                        </button>
+                                    </div>
+                                    <ul  
+                                    data-dropdown-target="menu"
+                                    class="hidden transition transform fixed bottom-28 z-10 w-52 bg-primary rounded-lg px-4 pt-2 pb-4 space-y-4 text-sm shadow-lg text-neutral"
+                                    data-transition-enter-from="opacity-0 scale-95"
+                                    data-transition-enter-to="opacity-100 scale-100"
+                                    data-transition-leave-from="opacity-100 scale-100"
+                                    data-transition-leave-to="opacity-0 scale-95"
+                                    >
+                                        <li><li><%= sort_link(@q_spots, 'rating', '高評価', { default_order: :desc }) %></li></li>
+                                        <li><%= sort_link(@q_spots, 'created_at desc', '新着順', { default_order: :desc }) %></li>
+                                        <li><%= sort_link(@q_spots, 'created_at asc', 'デフォルト', { default_order: :asc }) %></li>
+                                    </ul>
+                                </div>
+
+                                <!-- drawer component -->
+                                <div id="drawer-swipe" class="md:hidden fixed z-40 w-full overflow-y-auto bg-white border-t border-gray-200 rounded-t-lg dark:border-gray-700 dark:bg-gray-800 transition-transform bottom-0 left-0 right-0 translate-y-full bottom-[60px]" tabindex="-1" aria-labelledby="drawer-swipe-label">
+                                    <div class="p-4 cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-700" data-drawer-toggle="drawer-swipe">
+                                        <span class="absolute w-8 h-1 -translate-x-1/2 bg-gray-300 rounded-lg top-3 left-1/2 dark:bg-gray-600"></span>
+                                        <h5 id="drawer-swipe-label" class="inline-flex items-center text-base text-gray-500 dark:text-gray-400 font-medium">
+                                        <i class="ph-bold ph-list-magnifying-glass fa-2xl text-primary-hover"></i>&ensp;絞り込み</h5>
+                                    </div>
+                                    <div data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
+                                        <%= search_form_for @q_spots, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto px-8 pb-16", data: { turbo_frame: "spots-list" } }  do |f| %>
+                                            <label for="" class="mb-2 text-sm font-medium text-secondary sr-only dark:text-white">検索</label>
+                                            <div class="relative">
+                                                <div class="absolute inset-y-4 md:inset-y-3 start-0 flexed items-center ps-3 pointer-events-none">
+                                                    <i class="ph ph-magnifying-glass text-secondary"></i>
+                                                </div>
+                                                <%= f.search_field :name_or_address_cont, data: { autocomplete_target: 'input' }, class: 'block w-full p-4 md:p-3 ps-10 md:ps-8 text-sm text-secondary border border-secondary rounded-full bg-white focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
+                                                <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
+                                                <%= f.hidden_field :address, data: { autocomplete_target: 'hidden' } %>
+                                                <ul class="list-group absolute w-full bg-white p-2 shadow z-[1] rounded-box" data-autocomplete-target="results"></ul>
+                                            </div>
+                                            <div class="space-x-2 mt-8 mb-4">
+                                                <div class="my-1 inline-flex text-secondary text-xs rounded-lg py-1 px-1.5 bg-primary items-center hover:bg-primary-hover">
+                                                    <%= f.radio_button :with_tag, '', id: "tag_none", checked: true %>
+                                                    <%= f.label :with_tag, "指定なし", value: '', id: "tag_none" %>
+                                                </div>
+                                                <% @tags.each do |tag| %>
+                                                    <div class="my-1 group inline-flex text-secondary text-xs rounded-lg py-1 px-1.5 bg-primary items-center hover:bg-primary-hover">
+                                                        <%= f.radio_button :with_tag, tag.name, id: "tag_#{tag.id}" %>
+                                                        <i class="ph ph-tag"></i>&nbsp;<%= f.label :with_tag, tag.name, "tag_#{tag.id}" %>
+                                                    </div>
+                                                <% end %>
+                                            </div>
+                                            <div class="text-secondary flex-col items-center md:space-y-4">
+                                                <div class="flex space-x-4 md:space-x-0 md:flex-col pt-4 pl-2 mb-4 md:mb-0">
+                                                    <div class='label-select flex h-full text-sm space-x-2 items-center'>
+                                                        <%= f.check_box :foster_parents_eq, { include_hidden: false, class: 'search-select text-sm checkbox checkbox-sm checkbox-secondary [--chkbg:theme(colors.secondary)] [--chkfg:white]' }, 1, nil %>
+                                                        <%= f.label :foster_parents_eq, '里親募集あり', class: 'label text-sm font-semibold' %>
+                                                    </div>
+                                                    <div class='label-select flex h-full text-sm space-x-2 items-center'>
+                                                        <%= f.check_box :adoption_event_eq, { include_hidden: false, class: 'search-select text-sm checkbox checkbox-sm checkbox-secondary [--chkbg:theme(colors.secondary)] [--chkfg:white]' }, 1, nil %>
+                                                        <%= f.label :adoption_event_eq, '譲渡会開催あり', class: 'label text-sm font-semibold' %>
+                                                    </div>
+                                                </div>
+                                                <div class="flex space-x-4 mb-4">
+                                                    <div class='label-select h-full md:w-full w-1/2 text-sm'>
+                                                        <%= f.label :category_id_eq, 'カテゴリ', class: 'label text-sm font-semibold' %>
+                                                        <%= f.collection_select :category_id_eq, @categories, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
+                                                    </div>
+                                                    <div class='label-select h-full md:w-full w-1/2 text-sm md:mb-8'>
+                                                        <%= f.label :prefecture_id_eq, '都道府県', class: 'label text-sm font-semibold' %>
+                                                        <%= f.collection_select :prefecture_id_eq, @prefectures, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
+                                                    </div>
+                                                </div>
+                                                <div class="flex justify-center items-center mt-8 mb-4">
+                                                    <%= f.submit 'この条件で検索する', class: 'font-semibold text-sm rounded-md relative inline-flex group items-center justify-center px-3.5 py-2 m-1 cursor-pointer border-b-4 border-l-2 active:border-accent active:shadow-none shadow-lg bg-gradient-to-tr from-accent to-accent-active border-accent-hover text-white' do %>
+                                                        <span class="absolute w-0 h-0 transition-all duration-300 ease-out bg-white rounded-full group-hover:w-32 group-hover:h-32 opacity-10"></span>
+                                                        <span class="relative"></span>
+                                                    <% end %>
+                                                </div>
+                                            </div>
+                                        <% end %>
                                     </div>
                                 </div>
                                 <% if params[:q].present? && params[:q][:s].blank? %>
@@ -140,7 +214,7 @@
                                     </div>
                                 <% end %>
                                 <% if @spots.present? %>
-                                    <div class="pb-24 md:pb-16 md:pt-8 md:grid md:grid-cols-3 md:gap-8 md:pr-8 md:pl-4" data-controller="login-modal">
+                                    <div class="pb-16 pt-8 md:grid md:grid-cols-3 md:gap-8 md:pr-8 md:pl-4" data-controller="login-modal">
                                         <% @spots.each do |spot| %>
                                             <%= render 'spots/spot', spot: spot %>
                                         <% end %>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -40,61 +40,7 @@
                 <div class="w-full mx-auto md:h-full pb-8 ">
                     <div class="grid md:grid-cols-4">
                         <div class="md:block md:col-span-1 md:p-4 md:mt-12 hidden">
-                            <div data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
-                                <%= search_form_for @q_spots, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto py-8 md:py-4", data: { turbo_frame: "spots-list" } }  do |f| %>
-                                    <label for="" class="mb-2 text-sm font-medium text-secondary sr-only dark:text-white">検索</label>
-                                    <div class="relative">
-                                        <div class="absolute inset-y-4 md:inset-y-3 start-0 flexed items-center ps-3 pointer-events-none">
-                                            <i class="ph ph-magnifying-glass text-secondary"></i>
-                                        </div>
-                                        <%= f.search_field :name_or_address_cont, data: { autocomplete_target: 'input' }, class: 'block w-full p-4 md:p-3 ps-10 md:ps-8 text-sm text-secondary border border-secondary rounded-full bg-white focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
-                                        <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
-                                        <%= f.hidden_field :address, data: { autocomplete_target: 'hidden' } %>
-                                        <%= f.submit '検索', class: 'md:hidden text-white absolute fixed inset-y-2 end-2 py-2 h-9 bg-accent hover:bg-accent-hover focus:ring-4 focus:outline-none focus:ring-primary font-medium rounded-full text-sm px-4 py-0.5' %>
-                                        <ul class="list-group absolute w-full bg-white p-2 shadow z-[1] rounded-box" data-autocomplete-target="results"></ul>
-                                    </div>
-                                    <div class="space-x-2 my-4 ">
-                                        <div class="my-1 inline-flex text-secondary text-xs rounded-lg py-1 px-1.5 bg-primary items-center hover:bg-primary-hover">
-                                            <%= f.radio_button :with_tag, '', id: "tag_none", checked: true %>
-                                            <%= f.label :with_tag, "指定なし", value: '', id: "tag_none" %>
-                                        </div>
-                                        <% @tags.each do |tag| %>
-                                            <div class="my-1 group inline-flex text-secondary text-xs rounded-lg py-1 px-1.5 bg-primary items-center hover:bg-primary-hover">
-                                                <%= f.radio_button :with_tag, tag.name, id: "tag_#{tag.id}" %>
-                                                <i class="ph ph-tag"></i>&nbsp;<%= f.label :with_tag, tag.name, "tag_#{tag.id}" %>
-                                            </div>
-                                        <% end %>
-                                    </div>
-                                    <div class="text-secondary flex-col items-center md:space-y-4">
-                                        <div class="flex space-x-4 md:space-x-0 md:flex-col pt-4 pl-2 mb-4 md:mb-0">
-                                            <div class='label-select flex h-full text-sm space-x-2 items-center'>
-                                                <%= f.check_box :foster_parents_eq, { include_hidden: false, class: 'search-select text-sm checkbox checkbox-sm checkbox-secondary [--chkbg:theme(colors.secondary)] [--chkfg:white]' }, 1, nil %>
-                                                <%= f.label :foster_parents_eq, '里親募集あり', class: 'label text-sm font-semibold' %>
-                                            </div>
-                                            <div class='label-select flex h-full text-sm space-x-2 items-center'>
-                                                <%= f.check_box :adoption_event_eq, { include_hidden: false, class: 'search-select text-sm checkbox checkbox-sm checkbox-secondary [--chkbg:theme(colors.secondary)] [--chkfg:white]' }, 1, nil %>
-                                                <%= f.label :adoption_event_eq, '譲渡会開催あり', class: 'label text-sm font-semibold' %>
-                                            </div>
-                                        </div>
-                                        <div class="flex md:flex-col md:space-y-3 md:space-x-0 space-x-4 mb-4 md:mb-0">
-                                            <div class='label-select h-full md:w-full w-1/2 text-sm'>
-                                                <%= f.label :category_id_eq, 'カテゴリ', class: 'label text-sm font-semibold' %>
-                                                <%= f.collection_select :category_id_eq, @categories, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
-                                            </div>
-                                            <div class='label-select h-full md:w-full w-1/2 text-sm md:mb-8'>
-                                                <%= f.label :prefecture_id_eq, '都道府県', class: 'label text-sm font-semibold' %>
-                                                <%= f.collection_select :prefecture_id_eq, @prefectures, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
-                                            </div>
-                                        </div>
-                                        <div class="hidden md:flex justify-center items-center md:mt-12">
-                                            <%= f.submit 'この条件で検索する', class: 'font-semibold text-sm rounded-md relative inline-flex group items-center justify-center px-3.5 py-2 m-1 cursor-pointer border-b-4 border-l-2 active:border-accent active:shadow-none shadow-lg bg-gradient-to-tr from-accent to-accent-active border-accent-hover text-white' do %>
-                                                <span class="absolute w-0 h-0 transition-all duration-300 ease-out bg-white rounded-full group-hover:w-32 group-hover:h-32 opacity-10"></span>
-                                                <span class="relative"></span>
-                                            <% end %>
-                                        </div>
-                                    </div>
-                                <% end %>
-                            </div>
+                            <%= render 'spots/index_spot_search' %>
                         </div>
                         <div class="md:col-span-3">
                             <div class="flex justify-end items-center" data-controller="drawer">
@@ -138,7 +84,7 @@
                                     data-transition-leave-from="opacity-100 scale-100"
                                     data-transition-leave-to="opacity-0 scale-95"
                                     >
-                                        <li><li><%= sort_link(@q_spots, 'rating', '高評価', { default_order: :desc }) %></li></li>
+                                        <li><%= sort_link(@q_spots, 'rating', '高評価', { default_order: :desc }) %></li>
                                         <li><%= sort_link(@q_spots, 'created_at desc', '新着順', { default_order: :desc }) %></li>
                                         <li><%= sort_link(@q_spots, 'created_at asc', 'デフォルト', { default_order: :asc }) %></li>
                                     </ul>
@@ -151,60 +97,7 @@
                                         <h5 id="drawer-swipe-label" class="inline-flex items-center text-base text-gray-500 dark:text-gray-400 font-medium">
                                         <i class="ph-bold ph-list-magnifying-glass fa-2xl text-primary-hover"></i>&ensp;絞り込み</h5>
                                     </div>
-                                    <div data-controller="autocomplete" data-autocomplete-url-value="/spots/search" role="combobox">
-                                        <%= search_form_for @q_spots, url: spots_path, html: { id: "searchForm", class: "max-w-lg mx-auto px-8 pb-16", data: { turbo_frame: "spots-list" } }  do |f| %>
-                                            <label for="" class="mb-2 text-sm font-medium text-secondary sr-only dark:text-white">検索</label>
-                                            <div class="relative">
-                                                <div class="absolute inset-y-4 md:inset-y-3 start-0 flexed items-center ps-3 pointer-events-none">
-                                                    <i class="ph ph-magnifying-glass text-secondary"></i>
-                                                </div>
-                                                <%= f.search_field :name_or_address_cont, data: { autocomplete_target: 'input' }, class: 'block w-full p-4 md:p-3 ps-10 md:ps-8 text-sm text-secondary border border-secondary rounded-full bg-white focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500', placeholder: '猫スポット名または住所' %>
-                                                <%= f.hidden_field :name, data: { autocomplete_target: 'hidden' } %>
-                                                <%= f.hidden_field :address, data: { autocomplete_target: 'hidden' } %>
-                                                <ul class="list-group absolute w-full bg-white p-2 shadow z-[1] rounded-box" data-autocomplete-target="results"></ul>
-                                            </div>
-                                            <div class="space-x-2 mt-8 mb-4">
-                                                <div class="my-1 inline-flex text-secondary text-xs rounded-lg py-1 px-1.5 bg-primary items-center hover:bg-primary-hover">
-                                                    <%= f.radio_button :with_tag, '', id: "tag_none", checked: true %>
-                                                    <%= f.label :with_tag, "指定なし", value: '', id: "tag_none" %>
-                                                </div>
-                                                <% @tags.each do |tag| %>
-                                                    <div class="my-1 group inline-flex text-secondary text-xs rounded-lg py-1 px-1.5 bg-primary items-center hover:bg-primary-hover">
-                                                        <%= f.radio_button :with_tag, tag.name, id: "tag_#{tag.id}" %>
-                                                        <i class="ph ph-tag"></i>&nbsp;<%= f.label :with_tag, tag.name, "tag_#{tag.id}" %>
-                                                    </div>
-                                                <% end %>
-                                            </div>
-                                            <div class="text-secondary flex-col items-center md:space-y-4">
-                                                <div class="flex space-x-4 md:space-x-0 md:flex-col pt-4 pl-2 mb-4 md:mb-0">
-                                                    <div class='label-select flex h-full text-sm space-x-2 items-center'>
-                                                        <%= f.check_box :foster_parents_eq, { include_hidden: false, class: 'search-select text-sm checkbox checkbox-sm checkbox-secondary [--chkbg:theme(colors.secondary)] [--chkfg:white]' }, 1, nil %>
-                                                        <%= f.label :foster_parents_eq, '里親募集あり', class: 'label text-sm font-semibold' %>
-                                                    </div>
-                                                    <div class='label-select flex h-full text-sm space-x-2 items-center'>
-                                                        <%= f.check_box :adoption_event_eq, { include_hidden: false, class: 'search-select text-sm checkbox checkbox-sm checkbox-secondary [--chkbg:theme(colors.secondary)] [--chkfg:white]' }, 1, nil %>
-                                                        <%= f.label :adoption_event_eq, '譲渡会開催あり', class: 'label text-sm font-semibold' %>
-                                                    </div>
-                                                </div>
-                                                <div class="flex space-x-4 mb-4">
-                                                    <div class='label-select h-full md:w-full w-1/2 text-sm'>
-                                                        <%= f.label :category_id_eq, 'カテゴリ', class: 'label text-sm font-semibold' %>
-                                                        <%= f.collection_select :category_id_eq, @categories, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
-                                                    </div>
-                                                    <div class='label-select h-full md:w-full w-1/2 text-sm md:mb-8'>
-                                                        <%= f.label :prefecture_id_eq, '都道府県', class: 'label text-sm font-semibold' %>
-                                                        <%= f.collection_select :prefecture_id_eq, @prefectures, :id, :name,  { include_blank: '指定なし' }, { class: 'search-select bg-gray-50 border border-gray-300 text-secondary text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500' } %>
-                                                    </div>
-                                                </div>
-                                                <div class="flex justify-center items-center mt-8 mb-4">
-                                                    <%= f.submit 'この条件で検索する', class: 'font-semibold text-sm rounded-md relative inline-flex group items-center justify-center px-3.5 py-2 m-1 cursor-pointer border-b-4 border-l-2 active:border-accent active:shadow-none shadow-lg bg-gradient-to-tr from-accent to-accent-active border-accent-hover text-white' do %>
-                                                        <span class="absolute w-0 h-0 transition-all duration-300 ease-out bg-white rounded-full group-hover:w-32 group-hover:h-32 opacity-10"></span>
-                                                        <span class="relative"></span>
-                                                    <% end %>
-                                                </div>
-                                            </div>
-                                        <% end %>
-                                    </div>
+                                    <%= render 'spots/index_spot_search' %>
                                 </div>
                                 <% if params[:q].present? && params[:q][:s].blank? %>
                                     <div class="flex justify-start items-center md:px-8 max-[600px]:w-full max-[600px]:border-b-2 md:mt-8">

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -126,9 +126,9 @@
                                             <span class="text-[12px] text-secondary dark:text-gray-400 group-hover:text-neutral">並び替え</span>
                                         </div>
                                         <ul tabindex="0" class="dropdown-content menu bg-white rounded-box z-[1] w-52 p-2 shadow-lg text-neutral">
-                                            <li><%= sort_link(@q_spots, :rating, "高評価", { default_order: :desc }) %></li>
-                                            <li><%= sort_link(@q_spots, :created_at, "新着順", { default_order: :desc }) %></li>
-                                            <li><%= sort_link(@q_spots, :created_at, "デフォルト", { default_order: :asc }) %></li>
+                                            <li><li><%= sort_link(@q_spots, 'rating', '高評価', { default_order: :desc }) %></li></li>
+                                            <li><%= sort_link(@q_spots, 'created_at desc', '新着順', { default_order: :desc }) %></li>
+                                            <li><%= sort_link(@q_spots, 'created_at asc', '古い順', { default_order: :asc }) %></li>
                                         </ul>
                                     </div>
                                 </div>

--- a/app/views/spots/map.html.erb
+++ b/app/views/spots/map.html.erb
@@ -118,9 +118,14 @@
   </div>
 </div>
 
-<script>
-  window.defaultImagePath = "<%= asset_path('default-1920x1080.png') %>";
-</script>
+<% @spots.each do |spot| %>
+  <% prioritized_image = spot.prioritized_spot_image %>
+  <script>
+    window.defaultImagePath = "<%= asset_path('default-1920x1080.png') %>";
+    window.prioritizedImageUrls ||= {};
+    window.prioritizedImageUrls["<%= spot.id %>"] = "<%= prioritized_image ? spot_image_proxy_url(prioritized_image.image) : asset_path('default-1920x1080.png') %>";
+  </script>
+<% end %>
 
 <%= javascript_include_tag "gmap" %>
 

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,4 +1,5 @@
 <% content_for(:title, @spot.name) %>
+<% @image_url = spot_image_proxy_url(@prioritized_image.image) %>
 <% assign_meta_tags title: @spot.name, image: @image_url %>
 <nav class="md:hidden w-full h-12 ">
     <div class="navbar bg-primary text-secondary border-b border-primary-hover">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -17,7 +17,7 @@
     
     <% if @prioritized_image.present? %>
       <div class="swiper-slide h-96 w-full">
-        <%= image_tag "https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&photo_reference=#{@prioritized_image.image}&key=#{ENV['GMAP_API_KEY']}", class: "w-full h-96 object-cover", alt: "Prioritized Image" %>
+        <%= image_tag spot_image_proxy_url(@prioritized_image.image), class: "w-full h-96 object-cover", alt: "Prioritized Image" %>
       </div>
     <% else %>
       <div class="swiper-slide h-96 w-full">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -29,7 +29,7 @@
       <% @spot.spot_images.each_with_index do |image, index| %>
         <% unless image == @prioritized_image %>
           <div class="swiper-slide h-96 w-full">
-            <%= image_tag "https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&photo_reference=#{image.image}&key=#{ENV['GMAP_API_KEY']}", class: "w-full h-96 object-cover", alt: "Image #{index + 1}" %>
+            <%= image_tag spot_image_proxy_url(image.image), class: "w-full h-96 object-cover", alt: "Image #{index + 1}" %>
           </div>
         <% end %>
       <% end %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -13,9 +13,8 @@
 
 <% flash.empty? ? flash_class = "md:mt-16" : flash_class = "" %>
 <div class="bg-primary relative md:pb-16 md:mb-0 mb-20 <%= flash_class %>" data-controller="login-modal">
-<div class="swiper mySwiper">
-  <div class="swiper-wrapper">
-    
+  <div class="swiper mySwiper">
+    <div class="swiper-wrapper">
     <% if @prioritized_image.present? %>
       <div class="swiper-slide h-96 w-full">
         <%= image_tag spot_image_proxy_url(@prioritized_image.image), class: "w-full h-96 object-cover", alt: "Prioritized Image" %>
@@ -43,27 +42,26 @@
   <div class="swiper-scrollbar"></div>
 </div>
 
-  <!-- スポット詳細タブ -->
-  <div class="flex flex-col items-center justify-center w-full md:mt-4">
-    <div class="md:w-11/12 w-full">
-      <div data-controller="tabs rounded-t-lg" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-lg">
-        <ul class="list-reset flex border-b rounded-t-lg">
-          <li class="-mb-px mr-1 w-1/2 bg-white rounded-t-lg text-center" data-tabs-target="tab" data-action="click->tabs#change">
-            <a class="bg-white inline-block py-2 px-4 rounded-t-lg text-secondary hover:text-neutral font-semibold no-underline rounded-t-lg" href="#" data-turbo="false">詳細情報</a>
-          </li>
-          <li class="mr-1 w-1/2 bg-white rounded-t-lg text-center" data-tabs-target="tab" data-action="click->tabs#change">
-            <a class="bg-white inline-block py-2 px-4 rounded-t-lg text-secondary hover:text-neutral font-semibold no-underline rounded-t-lg" id="review_tab" href="#" data-turbo="false">口コミ(<%= @reviews.present? ? @all_reviews_count : 0 %>件)</a>
-          </li>
-        </ul>
-
-        <div id="details-tab" class="hidden bg-white py-4 px-4 w-full border-l border-b border-r rounded-b-lg rounded-r-lg" data-tabs-target="panel">
-          <div class="grid md:grid-cols-3">
-            <% if @spot.x_account.present? %>
-              <div class="text-secondary hidden md:block md:col-span-1 w-11/12 md:pl-4">
-                <p class="text-[16px] pb-4 pt-8 font-bold"><i class="ph-bold ph-megaphone"></i> 最新情報</p>
-                <a class="twitter-timeline" data-height="500" href="https://twitter.com/<%= @spot.x_account %>?ref_src=twsrc%5Etfw">Tweets by <%= @spot.name %></a>
-              </div>
-            <% end %>
+<!-- スポット詳細タブ -->
+<div class="flex flex-col items-center justify-center w-full md:mt-4">
+  <div class="md:w-11/12 w-full">
+    <div data-controller="tabs rounded-t-lg" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-lg">
+      <ul class="list-reset flex border-b rounded-t-lg">
+        <li class="-mb-px mr-1 w-1/2 bg-white rounded-t-lg text-center" data-tabs-target="tab" data-action="click->tabs#change">
+          <a class="bg-white inline-block py-2 px-4 rounded-t-lg text-secondary hover:text-neutral font-semibold no-underline rounded-t-lg" href="#" data-turbo="false">詳細情報</a>
+        </li>
+        <li class="mr-1 w-1/2 bg-white rounded-t-lg text-center" data-tabs-target="tab" data-action="click->tabs#change">
+          <a class="bg-white inline-block py-2 px-4 rounded-t-lg text-secondary hover:text-neutral font-semibold no-underline rounded-t-lg" id="review_tab" href="#" data-turbo="false">口コミ(<%= @reviews.present? ? @all_reviews_count : 0 %>件)</a>
+        </li>
+      </ul>
+      <div id="details-tab" class="hidden bg-white py-4 px-4 w-full border-l border-b border-r rounded-b-lg rounded-r-lg" data-tabs-target="panel">
+        <div class="grid md:grid-cols-3">
+          <% if @spot.x_account.present? %>
+            <div class="text-secondary hidden md:block md:col-span-1 w-11/12 md:pl-4">
+              <p class="text-[16px] pb-4 pt-8 font-bold"><i class="ph-bold ph-megaphone"></i> 最新情報</p>
+              <a class="twitter-timeline" data-height="500" href="https://twitter.com/<%= @spot.x_account %>?ref_src=twsrc%5Etfw">Tweets by <%= @spot.name %></a>
+            </div>
+          <% end %>
           <div class="w-11/12 mx-auto divide-y space-y-8 pb-8 md:col-span-2" >
             <div class="my-4 mx-auto">
               <h2 class="text-xl font-zenmaru font-bold text-neutral"><%= @spot.name %></h2>
@@ -84,34 +82,37 @@
                         <div class="bg-primary px-2 py-1 rounded-md shadow-md text-secondary font-semibold text-sm items-center font-zenmaru">譲</div>
                     <% end %>
                   </div>
-                    <button class="btn bg-white border-none w-6 h-6 shadow-none md:rounded-full items-center" onclick="m_modal_3.showModal()"><i class="ph-bold ph-question fa-xl text-primary-hover"></i></button>
-                    <dialog id="m_modal_3" class="modal">
+                  <button class="btn bg-white border-none w-6 h-6 shadow-none md:rounded-full items-center" onclick="m_modal_3.showModal()"><i class="ph-bold ph-question fa-xl text-primary-hover"></i></button>
+                  <dialog id="m_modal_3" class="modal">
                     <div class="modal-box">
-                    <div class="flex justify-center items-center">
-                            <div class="flex flex-col space-y-4 text-left text-secondary">
-                                <h2 class="text-xl font-zenmaru font-bold text-neutral text-center">ボタン説明</h2>
-                                <div><i class="ph-fill ph-heart fa-xl w-full h-3 mt-2 text-gray-400"></i><span class="text-sm">&ensp;&ensp;：ブックマーク</span></div>
-                                <div><i class="ph-fill ph-seal-check fa-xl w-full h-3 mt-2 text-gray-400"></i><span class="text-sm">&ensp;&ensp;：訪問済にする</span></div>
-                                <h2 class="text-xl font-zenmaru font-bold text-neutral text-center">マーク説明</h2>
-                                <div><div class="inline-flex bg-primary px-2 py-1 rounded-md shadow-md text-secondary font-semibold text-sm items-center font-zenmaru">里</div><span class="text-sm">&ensp;：里親募集中</span></div>
-                                <div><div class="inline-flex bg-primary px-2 py-1 rounded-md shadow-md text-secondary font-semibold text-sm items-center font-zenmaru">譲</div><span class="text-sm">&ensp;：譲渡会開催実績あり</span></div>
-                                <div><div class="flex-cols px-2 py-1 rounded-md shadow-md text-white font-semibold text-xs items-center bg-accent"><span><i class="ph-bold ph-warning"></i>&ensp;注意</span><br>里親募集や譲渡会の詳細につきましては、各猫スポットの公式サイトやSNSでご確認ください。</div></div>
-                            </div>
+                      <div class="flex justify-center items-center">
+                        <div class="flex flex-col space-y-4 text-left text-secondary">
+                            <h2 class="text-xl font-zenmaru font-bold text-neutral text-center">ボタン説明</h2>
+                            <div><i class="ph-fill ph-heart fa-xl w-full h-3 mt-2 text-gray-400"></i><span class="text-sm">&ensp;&ensp;：ブックマーク</span></div>
+                            <div><i class="ph-fill ph-seal-check fa-xl w-full h-3 mt-2 text-gray-400"></i><span class="text-sm">&ensp;&ensp;：訪問済にする</span></div>
+                            <h2 class="text-xl font-zenmaru font-bold text-neutral text-center">マーク説明</h2>
+                            <div><div class="inline-flex bg-primary px-2 py-1 rounded-md shadow-md text-secondary font-semibold text-sm items-center font-zenmaru">里</div><span class="text-sm">&ensp;：里親募集中</span></div>
+                            <div><div class="inline-flex bg-primary px-2 py-1 rounded-md shadow-md text-secondary font-semibold text-sm items-center font-zenmaru">譲</div><span class="text-sm">&ensp;：譲渡会開催実績あり</span></div>
+                            <div><div class="flex-cols px-2 py-1 rounded-md shadow-md text-white font-semibold text-xs items-center bg-accent"><span><i class="ph-bold ph-warning"></i>&ensp;注意</span><br>里親募集や譲渡会の詳細につきましては、各猫スポットの公式サイトやSNSでご確認ください。</div></div>
                         </div>
+                      </div>
                     </div>
                     <form method="dialog" class="modal-backdrop">
                         <button>close</button>
                     </form>
-                    </dialog>
+                  </dialog>
                 </div>
                 <div class="flex space-x-2 items-center">
-                  <div class="items-center">
-                    <div class="line-it-button" data-lang="ja" data-type="share-b" data-env="REAL" data-url="https://nekospot.jp/spots/<%= @spot.id %>" data-color="default" data-size="small" data-count="false" data-ver="3" style="display: none;"></div>
-                    <script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"></script>
-                  </div>
-                  <div class="items-center">
-                    <%= link_to "https://twitter.com/share?url=https://nekospot.jp/spots/#{@spot.id}/&text=#{ERB::Util.url_encode("「#{@spot.name}」をシェアしたよ🐈✨\n #NekoSpot \n")}", target: '_blank', class: "mt-2 inline-flex flex-col items-center justify-center px-1 group" do %>
-                      <%= image_tag "logo-black.png", size: "24x24" %>
+                  <div class="flex space-x-2 justify-center items-center">
+                    <div class="hidden md:block">
+                      <div class="line-it-button" data-lang="ja" data-type="share-a" data-env="REAL" data-url="https://nekospot.jp/spots/<%= @spot.id %>" data-color="default" data-size="large" data-count="false" data-ver="3" style="display: none;"></div>
+                    </div>
+                    <div class="md:hidden">
+                      <div class="line-it-button md:hidden" data-lang="ja" data-type="share-a" data-env="REAL" data-url="https://nekospot.jp/spots/<%= @spot.id %>" data-color="default" data-size="small" data-count="false" data-ver="3" style="display: none;"></div>
+                    </div>
+                    <%= link_to "https://twitter.com/share?url=https://nekospot.jp/spots/#{@spot.id}/&text=#{ERB::Util.url_encode("「#{@spot.name}」をシェアしたよ🐈✨\n #NekoSpot \n")}", target: '_blank', class: "relative rounded md:px-3 px-2 py-0 md:py-1 overflow-hidden group bg-neutral relative hover:bg-gradient-to-r hover:from-neutral hover:to-secondary text-white hover:ring-2 hover:ring-offset-2 hover:ring-secondary transition-all ease-out duration-300" do %>
+                      <span class="absolute right-0 w-8 h-32 -mt-12 transition-all duration-1000 transform translate-x-12 bg-white opacity-10 rotate-12 group-hover:-translate-x-40 ease"></span>
+                      <span class="relative md:text-sm text-[10px] text-white dark:text-gray-400 "><i class="ph-bold ph-x-logo fa-lg w-6 h-3" aria-hidden="true"></i>&nbsp;シェア</span>
                     <% end %>
                   </div>
                   <div><%= render 'visited_buttons', { spot: @spot } %></div>
@@ -119,15 +120,15 @@
                 </div>
               </div>
               <% if @spot.x_account.present? %>
-              <div class="flex justify-center items-center md:hidden mt-8 w-full">
-                <a href="https://twitter.com/<%= @spot.x_account %>" target=”_blank” class="w-4/5 relative inline-flex items-center justify-center p-4 px-6 py-3 overflow-hidden font-medium text-secondary transition duration-300 ease-out border-2 border-secondary rounded-full shadow-md group">
-                <span class="absolute inset-0 flex items-center justify-center w-full h-full text-white duration-300 -translate-x-full bg-secondary group-hover:translate-x-0 ease">
-                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path></svg>
-                </span>
-                <span class="absolute flex items-center justify-center w-full h-full text-secondary transition-all duration-300 transform group-hover:translate-x-full ease"><i class="ph-bold ph-x-logo fa-lg"></i>&ensp;最新情報をチェック</span>
-                <span class="relative invisible">Button Text</span>
-                </a>
-              </div>
+                <div class="flex justify-center items-center md:hidden mt-8 w-full">
+                  <a href="https://twitter.com/<%= @spot.x_account %>" target=”_blank” class="w-4/5 relative inline-flex items-center justify-center p-4 px-6 py-3 overflow-hidden font-medium text-secondary transition duration-300 ease-out border-2 border-secondary rounded-full shadow-md group">
+                    <span class="absolute inset-0 flex items-center justify-center w-full h-full text-white duration-300 -translate-x-full bg-secondary group-hover:translate-x-0 ease">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14 5l7 7m0 0l-7 7m7-7H3"></path></svg>
+                    </span>
+                    <span class="absolute flex items-center justify-center w-full h-full text-secondary transition-all duration-300 transform group-hover:translate-x-full ease"><i class="ph-bold ph-x-logo fa-lg"></i>&ensp;最新情報をチェック</span>
+                    <span class="relative invisible">Button Text</span>
+                  </a>
+                </div>
               <% end %>
             </div>
             <% if @spot.opening_hours.present? %>
@@ -148,69 +149,78 @@
                 <%= link_to @spot.web_site, @spot.web_site, class: "text-sm", target: :_blank %>
               </div>
             <% end %>
-        <div class="my-4 text-secondary">
-          <p class="text-sm pb-4 pt-8 font-bold"><i class="ph-fill ph-map-pin"></i> 住所</p>
-          <div class="flex justify-start">
+            <div class="my-4 text-secondary">
+              <p class="text-sm pb-4 pt-8 font-bold"><i class="ph-fill ph-map-pin"></i> 住所</p>
+              <div class="flex justify-start">
+                <div>
+                  <p class="text-sm"><%= @spot.postal_code %></p>
+                  <p class="text-sm mb-4"><%= @spot.address %></p>
+                </div>
+              </div>
             <div>
-              <p class="text-sm"><%= @spot.postal_code %></p>
-              <p class="text-sm mb-4"><%= @spot.address %></p>
-            </div>
-          </div>
-          <div>
             <iframe frameborder="0" class="w-full md:h-64 h-48 rounded-xl" src="https://www.google.com/maps/embed/v1/place?key=<%= ENV['EMBED_API_KEY'] %>&q=<%= @spot.address %>">
             </iframe>
-          </div>
-          <div id="map"  data-lat="<%= @spot.latitude %>" data-lng="<%= @spot.longitude %>" data-name="<%= @spot.name %>"></div>
-          <div class="flex justify-end mt-4">
-            <%= link_to "https://www.google.com/maps/dir/?api=1&destination=#{@spot.latitude},#{@spot.longitude}", target: :_blank, class: "inline-flex items-center justify-end w-auto px-4 py-2 text-base text-sm font-semibold leading-6 text-white bg-accent border border-transparent rounded-full hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent-active" do %>
-              <p><i class="ph-fill ph-path"></i> 経路</p>
-            <% end %>
-          </div>
+            <div id="map"  data-lat="<%= @spot.latitude %>" data-lng="<%= @spot.longitude %>" data-name="<%= @spot.name %>"></div>
+            <div class="flex justify-end mt-4">
+              <%= link_to "https://www.google.com/maps/dir/?api=1&destination=#{@spot.latitude},#{@spot.longitude}", target: :_blank, class: "inline-flex items-center justify-end w-auto px-4 py-2 text-base text-sm font-semibold leading-6 text-white bg-accent border border-transparent rounded-full hover:bg-accent-hover focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-accent-active" do %>
+                <p><i class="ph-fill ph-path"></i> 経路</p>
+              <% end %>
+            </div>
+            <div class="my-4 text-secondary w-full border-t">
+              <p class="text-sm pb-4 pt-8 font-bold"><i class="ph ph-export"></i> シェア</p>
+              <div class="flex space-x-2 justify-center items-center">
+                <div class="line-it-button" data-lang="ja" data-type="share-a" data-env="REAL" data-url="https://nekospot.jp/spots/<%= @spot.id %>" data-color="default" data-size="large" data-count="false" data-ver="3" style="display: none;"></div>
+                <%= link_to "https://twitter.com/share?url=https://nekospot.jp/spots/#{@spot.id}/&text=#{ERB::Util.url_encode("「#{@spot.name}」をシェアしたよ🐈✨\n #NekoSpot \n")}", target: '_blank', class: "relative rounded px-3 py-1 overflow-hidden group bg-neutral relative hover:bg-gradient-to-r hover:from-neutral hover:to-secondary text-white hover:ring-2 hover:ring-offset-2 hover:ring-secondary transition-all ease-out duration-300" do %>
+                  <span class="absolute right-0 w-8 h-32 -mt-12 transition-all duration-1000 transform translate-x-12 bg-white opacity-10 rotate-12 group-hover:-translate-x-40 ease"></span>
+                  <span class="relative text-sm text-white dark:text-gray-400 "><i class="ph-bold ph-x-logo fa-lg w-6 h-3" aria-hidden="true"></i>シェア</span>
+                <% end %>
+              </div>
+            </div>
           </div>
         </div>
       </div>
     </div>
+  </div>
 
-      <!-- レビュータブ -->
-      <div id="reviews-tab" class="hidden bg-white p-4 w-full border-l border-b border-r rounded-l-lg rounded-b-lg" data-tabs-target="panel">
-        <div id="reviews_list">
-        <% if @reviews.present? %>
-          <div class="grid sm:grid-cols-2 lg:grid-cols-3 lg:gap-12">
-            <div>
-              <div class="md:mx-8 my-3 rounded-lg border p-4 mx-auto justify-center items-center">
-                <h2 class="pl-3 mb-3 text-xl font-zenmaru font-bold text-neutral">スポット平均</h2>
-        
-                <div class="mb-0.5 flex items-center gap-2">
-                  <!-- stars - start -->
-                  <div class="rating rating-md rating-half" id="average_rating">
-                    <input type="radio" name="rating-10" class="rating-hidden" />
-                      <% (1..5).each do |i| %>
-                          <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-1" <%= 'checked' if @average_rating >= (i - 0.5) && @average_rating < i %> />
-                          <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-2" <%= 'checked' if @average_rating >= i %> />
-                      <% end %>
-                      <span class="text-sm font-semibold text-secondary"><%= @average_rating.round(2) %></span>
-                  </div>
-                  <span class="text-sm font-semibold text-secondary" id="reviews_count"> (<%= @all_reviews_count %>件)</span>
+  <!-- レビュータブ -->
+  <div id="reviews-tab" class="hidden bg-white p-4 w-full border-l border-b border-r rounded-l-lg rounded-b-lg" data-tabs-target="panel">
+    <div id="reviews_list">
+      <% if @reviews.present? %>
+        <div class="grid sm:grid-cols-2 lg:grid-cols-3 lg:gap-12">
+          <div>
+            <div class="md:mx-8 my-3 rounded-lg border p-4 mx-auto justify-center items-center">
+              <h2 class="pl-3 mb-3 text-xl font-zenmaru font-bold text-neutral">スポット平均</h2>
+              <div class="mb-0.5 flex items-center gap-2">
+                <!-- stars - start -->
+                <div class="rating rating-md rating-half" id="average_rating">
+                  <input type="radio" name="rating-10" class="rating-hidden" />
+                  <% (1..5).each do |i| %>
+                      <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-1" <%= 'checked' if @average_rating >= (i - 0.5) && @average_rating < i %> />
+                      <input type="radio" name="rating-10" class="bg-yellow-400 mask mask-star-2 mask-half-2" <%= 'checked' if @average_rating >= i %> />
+                  <% end %>
+                  <span class="text-sm font-semibold text-secondary"><%= @average_rating.round(2) %></span>
                 </div>
+                <span class="text-sm font-semibold text-secondary" id="reviews_count"> (<%= @all_reviews_count %>件)</span>
               </div>
             </div>
-            <div class="lg:col-span-2 md:mr-8">
-              <%= turbo_frame_tag 'review_modal' do %>
-              <%= turbo_frame_tag 'tags_search' do %>
-                <h2 class="my-3 text-xl font-zenmaru font-bold text-neutral border-bottom">口コミ一覧</h2>
-                <%= link_to spot_path(@spot), data: { turbo_frame: "tags_search" }, class: "inline-block text-sm px-4 py-2 mx-auto text-secondary bg-primary rounded-lg hover:bg-primary-hover md:mx-0" do %>
-                  <i class="ph ph-tag"></i>&nbsp;タグ検索解除
-                <% end %>
-                <div class="grid">
-                  <div id="reviews" class="space-y-8 divide-gray-200 divide-y">
-                    <%= render @reviews %>
-                  </div>
-                  <%= paginate @reviews %>
+          </div>
+        <div class="lg:col-span-2 md:mr-8">
+          <%= turbo_frame_tag 'review_modal' do %>
+            <%= turbo_frame_tag 'tags_search' do %>
+              <h2 class="my-3 text-xl font-zenmaru font-bold text-neutral border-bottom">口コミ一覧</h2>
+              <%= link_to spot_path(@spot), data: { turbo_frame: "tags_search" }, class: "inline-block text-sm px-4 py-2 mx-auto text-secondary bg-primary rounded-lg hover:bg-primary-hover md:mx-0" do %>
+                <i class="ph ph-tag"></i>&nbsp;タグ検索解除
+              <% end %>
+              <div class="grid">
+                <div id="reviews" class="space-y-8 divide-gray-200 divide-y">
+                  <%= render @reviews %>
                 </div>
-              <% end %>
-              <% end %>
-            </div>
-          <% else %>
+                <%= paginate @reviews %>
+              </div>
+            <% end %>
+          <% end %>
+        </div>
+      <% else %>
             <div id="no_reviews">
               <%= render 'spots/no_reviews' %>
             </div>
@@ -237,6 +247,7 @@
   </div>
 
   <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  <script src="https://www.line-website.com/social-plugins/js/thirdparty/loader.min.js" async="async" defer="defer"></script>
 
 <script>
   document.addEventListener('DOMContentLoaded', function () {
@@ -292,3 +303,4 @@
     }
 });
 </script>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
     get '/users/sign_out' => 'devise/sessions#destroy'
     get '/users/auth/failure' => 'omniauth_callbacks#failure'
   end
+  get 'spot_images/:photo_reference', to: 'spot_images#show', as: 'spot_image_proxy'
   get 'static_pages/index'
   get 'privacy_policy', to: 'static_pages#privacy_policy'
   get 'terms_of_use', to: 'static_pages#terms_of_use'
@@ -32,6 +33,11 @@ Rails.application.routes.draw do
       get :map
       get :search
       get :visits
+    end
+  end
+  resources :screenshots, only: [:create] do
+    collection do
+      post :update_meta_tags
     end
   end
   resources :spot_bookmarks, only: %i[create destroy]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@hotwired/turbo-rails": "^8.0.4",
+    "@stimulus-components/dropdown": "^3.0.0",
     "autoprefixer": "^10.4.19",
     "daisyui": "^4.10.1",
     "esbuild": "^0.21.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -236,6 +236,13 @@
   resolved "https://registry.yarnpkg.com/@rails/actioncable/-/actioncable-7.1.3.tgz#4db480347775aeecd4dde2405659eef74a458881"
   integrity sha512-ojNvnoZtPN0pYvVFtlO7dyEN9Oml1B6IDM+whGKVak69MMYW99lC2NOWXWeE3bmwEydbP/nn6ERcpfjHVjYQjA==
 
+"@stimulus-components/dropdown@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@stimulus-components/dropdown/-/dropdown-3.0.0.tgz#b85efa8ef06a94eac1a40e52ac920f5089789c8e"
+  integrity sha512-GY9Ez8T5Vbcad702seF4iuKZwv4f+VACtfO527l8vrFDFbGWWFyRljyK9FFXSPEkUC3/4PilVsYfPO2CMikkEg==
+  dependencies:
+    stimulus-use "^0.52.2"
+
 accepts@~1.3.5:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -2170,6 +2177,11 @@ stimulus-autocomplete@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
   integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
+stimulus-use@^0.52.2:
+  version "0.52.2"
+  resolved "https://registry.yarnpkg.com/stimulus-use/-/stimulus-use-0.52.2.tgz#fc992fababe03f8d8bc2d9470c8cdb40bd075917"
+  integrity sha512-413+tIw9n6Jnb0OFiQE1i3aP01i0hhGgAnPp1P6cNuBbhhqG2IOp8t1O/4s5Tw2lTvSYrFeLNdaY8sYlDaULeg==
 
 "string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"


### PR DESCRIPTION
# 概要
## やったこと
- `rating DESC NULLS LAST`を指定することにより、高評価順に並び替えた時に評価がnullのスポットが最後に表示されるようにした。
- Flowbiteを導入しスマホ画面でのスポット一覧の検索機能をドロワー内に格納した。
- FlowbiteのCSSを読み込むと他のCSSが効かなくなったため、CSSは読み込まず背景のオーバーフローはstimulusで制御した。
- Google PlacesAPIから取得した画像の表示方法を、プロキシエンドポイントを使ってAPIキーをクライアントサイドで露出させずに画像を表示するように修正。
- スポット詳細をシェアした際に、動的にOGPが表示されるようにした
- その他レイアウト調整