### PR TITLE
🐛 Fix:スポット詳細のOGPが表示されるように修正 / 本番環境でテスト

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -106,7 +106,7 @@ class SpotsController < ApplicationController
     @all_reviews_count = @spot.reviews.count
     @average_rating = @spot.reviews.average(:rating).to_f
     @prioritized_image = @spot.prioritized_spot_image # 優先的に表示する画像を取得
-    @image_url = @spot.process_image(spot_image_proxy_url(@prioritized_image.image))
+    @image_url = @spot.ogp_image
   end
 
   def search
@@ -132,10 +132,12 @@ class SpotsController < ApplicationController
     url = "https://maps.googleapis.com/maps/api/place/photo?maxheight=1000&photo_reference=#{photo_reference}&key=#{ENV['GMAP_API_KEY']}"
     
     begin
-      image_data = open(url).read
+      image_data = URI.open(url).read
       send_data image_data, type: 'image/jpeg', disposition: 'inline'
     rescue OpenURI::HTTPError => e
       render plain: "Image not found", status: :not_found
+    rescue => e
+      render plain: "An error occurred: #{e.message}", status: :internal_server_error
     end
   end
 

--- a/app/uploaders/processed_image_uploader.rb
+++ b/app/uploaders/processed_image_uploader.rb
@@ -26,7 +26,7 @@ class ProcessedImageUploader < CarrierWave::Uploader::Base
   # end
   version :ogp do
     process resize_to_fill: [1200, 630] # OGP推奨サイズ
-    process convert: 'png'
+    process convert: 'webp'
   end
   # Process files as they are uploaded:
   # process scale: [200, 300]
@@ -43,12 +43,12 @@ class ProcessedImageUploader < CarrierWave::Uploader::Base
   # Add an allowlist of extensions which are allowed to be uploaded.
   # For images you might use something like this:
   def extension_allowlist
-    %w(jpg jpeg gif png)
+    %w(jpg jpeg gif png webp)
   end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.
   def filename
-    "processed_image_#{model.id}.png" if original_filename
+    "processed_image_#{model.id}.webp" if original_filename
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -73,4 +73,5 @@ Rails.application.configure do
 
   # Raise error when a before_action's only/except options reference missing actions
   config.action_controller.raise_on_missing_callback_actions = true
+  Rails.application.routes.default_url_options[:host] = 'http://localhost:3000'
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -94,4 +94,5 @@ Rails.application.configure do
   # ]
   # Skip DNS rebinding protection for the default health check endpoint.
   # config.host_authorization = { exclude: ->(request) { request.path == "/up" } }
+  Rails.application.routes.default_url_options[:host] = 'https://nekospot.jp'
 end

--- a/db/migrate/20240715073357_add_ogp_image_to_spots.rb
+++ b/db/migrate/20240715073357_add_ogp_image_to_spots.rb
@@ -1,0 +1,5 @@
+class AddOgpImageToSpots < ActiveRecord::Migration[7.1]
+  def change
+    add_column :spots, :ogp_image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_06_19_045505) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_15_073357) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -123,6 +123,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_06_19_045505) do
     t.integer "adoption_event", default: 0, null: false
     t.integer "age_limit", default: 0, null: false
     t.string "x_account"
+    t.string "ogp_image"
     t.index ["category_id"], name: "index_spots_on_category_id"
   end
 

--- a/lib/tasks/generate_ogp_images.rake
+++ b/lib/tasks/generate_ogp_images.rake
@@ -1,0 +1,60 @@
+namespace :spot do
+    desc "スポット詳細のOGP画像を生成"
+    task generate_ogp_images: :environment do
+        include Rails.application.routes.url_helpers
+    
+        host = Rails.env.production? ? 'https://nekospot.jp' : 'http://localhost:3000'
+    
+        spot_id = ENV['SPOT_ID']
+    
+        if spot_id
+            spot = Spot.includes(:spot_images).find_by(id: spot_id)
+    
+            if spot.nil?
+            puts "スポットID: #{spot_id} は存在しません"
+            elsif spot.spot_images.any? { |image| image.image.present? } && spot.ogp_image.blank?
+            prioritized_image = spot.prioritized_spot_image
+    
+            if prioritized_image && prioritized_image.image.present?
+                proxy_image_url = proxy_image_url(photo_reference: prioritized_image.image, host: host)
+    
+                begin
+                spot.process_image(proxy_image_url)
+                spot.save!
+                puts "OGP画像が生成されました。スポットID: #{spot.id}"
+                puts "----------"
+                rescue => e
+                puts "スポットID: #{spot.id} のOGP画像生成に失敗しました - エラー: #{e.message}"
+                puts "----------"
+                end
+            else
+                puts "有効な優先画像が見つかりません。スポットID: #{spot.id}"
+                puts "----------"
+            end
+            end
+        else
+            Spot.includes(:spot_images).find_each do |spot|
+            if spot.spot_images.any? { |image| image.image.present? } && spot.ogp_image.blank?
+                prioritized_image = spot.prioritized_spot_image
+    
+                if prioritized_image && prioritized_image.image.present?
+                proxy_image_url = proxy_image_url(photo_reference: prioritized_image.image, host: host)
+    
+                begin
+                    spot.process_image(proxy_image_url)
+                    spot.save!
+                    puts "OGP画像が生成されました。スポットID: #{spot.id}"
+                    puts "----------"
+                rescue => e
+                    puts "スポットID: #{spot.id} のOGP画像生成に失敗しました - エラー: #{e.message}"
+                    puts "----------"
+                end
+                else
+                puts "有効な優先画像が見つかりません。スポットID: #{spot.id}"
+                puts "----------"
+                end
+            end
+            end
+        end
+    end
+end


### PR DESCRIPTION
# 概要
## やったこと
- Spotsテーブルに`ogp_image`カラムを追加
- `spots_controller`の`proxy_image`アクションを利用して、OGP画像のファイル名にAPIキーが載らないようにした
- `lib/tasks/generate_ogp_images.rake`を作成しOGP画像が保存されるようにした