### PR TITLE
266 レイアウト調整

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -103,7 +103,7 @@ module ApplicationHelper
       }
     
       # 特定のキーを除外するためのセット
-      excluded_keys = ["name", "address"]
+      excluded_keys = ["name", "address", "s"]
     
       conditions = params[:q].to_unsafe_h.map do |key, value|
         next if value.blank? || excluded_keys.include?(key)
@@ -126,6 +126,12 @@ module ApplicationHelper
       end.compact
     
       conditions.join(', ')
+    end
+
+    def has_search_conditions?(params)
+      return false if params[:q].blank?
+    
+      params[:q].to_unsafe_h.any? { |key, value| key != 's' && value.present? }
     end
 
     def page_title(title = '')

--- a/app/javascript/controllers/drawer_controller.js
+++ b/app/javascript/controllers/drawer_controller.js
@@ -52,6 +52,29 @@ export default class extends Controller {
         this.hideBackdrop();
       });
     });
+
+    // Add touch events for swipe down to close
+    this.addSwipeListener(drawer);
+  }
+
+  addSwipeListener(drawer) {
+    let touchStartY = 0;
+
+    drawer.addEventListener('touchstart', (event) => {
+      touchStartY = event.touches[0].clientY;
+    });
+
+    drawer.addEventListener('touchmove', (event) => {
+      const touchEndY = event.touches[0].clientY;
+      if (touchStartY < touchEndY) {
+        // Swiping down
+        const touchDistance = touchEndY - touchStartY;
+        if (touchDistance > 100) { // Adjust this threshold as needed
+          drawer.classList.add('translate-y-full');
+          this.hideBackdrop();
+        }
+      }
+    });
   }
 
   showBackdrop() {

--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -4,7 +4,7 @@ class Review < ApplicationRecord
   has_many :helpfuls, dependent: :destroy
   has_many :review_tags, dependent: :destroy
   has_many :tags, through: :review_tags
-  attr_accessor :images_cache
+  attr_accessor :images_cache, :tag_names
   mount_uploaders :images, ImageUploader
   process_in_background :images
 
@@ -12,6 +12,7 @@ class Review < ApplicationRecord
   validates :rating, presence: true, numericality: { in: 1..5, message: "を入力してください" }
   validates :body, length: { maximum: 400 }
   validate :validate_image_count
+  validate :validate_tag_count
   #validate :validate_images
 
   # 画像削除を処理するメソッド
@@ -29,14 +30,17 @@ class Review < ApplicationRecord
     ["spot", "user"]
   end
 
-  def save_tags(save_review_tags)
-  # 既存のタグをクリアすることで、タグ編集時の重複を防ぐ
-  self.tags.clear
+  def save_tags(tag_list)
+    if tag_list.size > 5
+      errors.add(:tags, "タグは5件までです。")
+      return false
+    end
 
-  save_review_tags.each do |new_name| #カラムの中から同じ値がないか探して、あればそのままfindの動き、なければcreateの動きで新たにカラムに保存
-    review_tag = Tag.find_or_create_by(name: new_name)
-    self.tags << review_tag #タグを関連付ける
-  end
+    self.tags.clear
+    tag_list.each do |new_name|
+      review_tag = Tag.find_or_create_by(name: new_name)
+      self.tags << review_tag
+    end
   end
 
   # レビューの文字数を判定
@@ -52,6 +56,12 @@ class Review < ApplicationRecord
   def validate_image_count
     if images.size > 3
       errors.add(:images, "画像のアップロードは３枚までです。")
+    end
+  end
+
+  def validate_tag_count
+    if tags.size > 5
+      errors.add(:tags, "タグは5件までです。")
     end
   end
 

--- a/app/views/diagnostics/_spot.html.erb
+++ b/app/views/diagnostics/_spot.html.erb
@@ -16,7 +16,7 @@
             </div>
             <p class="md:px-1.5 md:mt-2 text-xs text-secondary dark:text-neutral-500"><%= formatted_address(@recommend_spot.address) %></p>
             <%= link_to spot_path(@recommend_spot), data: { turbo: false } do %>
-                <div class="font-bold text-sm text-neutral font-zenmaru md:px-1.5 overflow-hidden w-full whitespace-nowrap text-overflow-ellipsis break-words whitespace-pre-wrap"><%= @recommend_spot.name %></div>
+                <div class="font-bold text-sm text-neutral font-zenmaru md:px-1.5 overflow-hidden w-full whitespace-pre-wrap pr-1 line-clamp-1"><%= @recommend_spot.name %></div>
             <% end %>
             <p class="md:hidden text-secondary font-semibold text-sm pt-1">⭐️ <%= @recommend_spot.rating %></p>
             <div class="justify-between flex items-end h-full md:space-x-4 space-x-2">

--- a/app/views/diagnostics/result.html.erb
+++ b/app/views/diagnostics/result.html.erb
@@ -1,4 +1,7 @@
 <% content_for(:title, t('diagnostics.result.title')) %>
+<div id="flash">
+    <%= render 'layouts/flash_messages', flash: flash %>
+</div>
 <div class="flex md:flex-col justify-center items-center w-screen h-screen bg-primary md:pt-52 pb-16">
     <div class="w-11/12 bg-white rounded-xl">
         <div class="my-8 flex-col items-center justify-center">

--- a/app/views/diagnostics/show_question.html.erb
+++ b/app/views/diagnostics/show_question.html.erb
@@ -1,4 +1,7 @@
 <% content_for(:title, t('diagnostics.start.title')) %>
+<div id="flash">
+    <%= render 'layouts/flash_messages', flash: flash %>
+</div>
 <div data-controller="diagnostic">
     <div class="flex justify-center items-center h-screen w-screen text-secondary">
         <%= form_with url: answer_question_diagnostic_path(@question), method: :post, data: { diagnostic_target: "form" } do |f| %>

--- a/app/views/diagnostics/start.html.erb
+++ b/app/views/diagnostics/start.html.erb
@@ -1,4 +1,7 @@
 <% content_for(:title, t('diagnostics.start.title')) %>
+<div id="flash">
+    <%= render 'layouts/flash_messages', flash: flash %>
+</div>
 <div class="flex justify-center items-center w-screen h-screen md:mt-20">
     <div>
         <%= image_tag 'diagnostic.webp', :size =>'480x480', class: 'hidden md:block' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -92,9 +92,6 @@
       <%= render "shared/before_login_header" %>
     <% end %>
   <% end %>
-  <div id="flash">
-    <%= render 'layouts/flash_messages', flash: flash %>
-  </div>
     <%= yield %>
     <%= render "shared/footer" %>
     <script src="https://cdn.jsdelivr.net/npm/flowbite@2.4.1/dist/flowbite.turbo.min.js"></script>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -4,7 +4,7 @@
             data-review-modal-target="backGround"
             data-spot-id="<%= @spot.id %>" 
             data-action="click->review-modal#closeBackground">
-    <div class="modal-content relative bg-white rounded-xl shadow-lg py-4 md:mt-16 flex flex-col justify-center w-screen md:w-80 h-[550px]" data-review-modal-target="reviewModal">
+    <div class="modal-content relative bg-white rounded-xl shadow-lg py-4 md:mt-16 flex flex-col justify-center w-screen w-80 h-[550px]" data-review-modal-target="reviewModal">
       <div class="absolute top-3 right-4">
           <i class="ph ph-x h-6 w-6 text-secondary" data-action="click->review-modal#closeModal"></i>
       </div>

--- a/app/views/reviews/show.html.erb
+++ b/app/views/reviews/show.html.erb
@@ -1,4 +1,7 @@
 <% assign_meta_tags title: @review.spot.name, image: @first_ogp_image_url %>
+<div id="flash">
+<%= render 'layouts/flash_messages', flash: flash %>
+</div>
 <nav class="md:hidden w-full h-12 ">
     <div class="navbar bg-primary text-secondary border-b border-primary-hover">
         <div class="flex-1 items-center mb-3">

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -36,14 +36,14 @@
     <% if controller_name == 'spots' && action_name == 'show' %>
     <%= render "shared/spot_show_header" %>
   <% else %>
-<div class="fixed bottom-0 left-0 z-50 w-full h-12 bg-primary border-t border-primary-hover md:hidden" data-controller="login-modal">
+<div class="fixed bottom-0 left-0 z-50 w-full h-16 bg-primary border-t border-primary-hover md:hidden" data-controller="login-modal">
     <div class="grid h-full max-w-lg grid-cols-4 mx-auto font-medium" >
         <%= link_to map_spots_path, data: { turbo: false }, class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
-            <i class="ph ph-magnifying-glass fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
+            <i class="ph-bold ph-magnifying-glass fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
             <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">検索</span>
         <% end %>
         <%= link_to spots_path, class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
-            <i class="ph ph-list-dashes fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
+            <i class="ph-bold ph-list-dashes fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
             <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">一覧</span>
         <% end %>
         <%= link_to start_diagnostics_path, class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
@@ -51,7 +51,7 @@
             <span class="text-[9px] text-secondary group-hover:text-neutral">診断</span>
         <% end %>
         <button type="button" data-action="click->login-modal#openModal" class="inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group">
-            <i class="ph ph-sign-in fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
+            <i class="ph-bold ph-sign-in fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
             <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">ログイン</span>
         </button>
     </div>

--- a/app/views/shared/_footer_contents.html.erb
+++ b/app/views/shared/_footer_contents.html.erb
@@ -1,10 +1,10 @@
 <div class="footer footer-center p-10 bg-primary text-secondary rounded items-end w-screen">
-<nav class="grid grid-flow-col gap-4">
-<%= link_to '利用規約', terms_of_use_path %>
-<%= link_to 'プライバシー・ポリシー', privacy_policy_path %>
-<%= link_to 'お問い合わせ', 'https://twitter.com/819Chapchon', target: '_blank', rel: 'noopener noreferrer' %>
-</nav>
-<aside>
-<p>Copyright © 2024</p>
-</aside>
+    <nav class="grid grid-flow-col gap-4">
+        <%= link_to '利用規約', terms_of_use_path %>
+        <%= link_to 'プライバシー・ポリシー', privacy_policy_path %>
+        <%= link_to 'お問い合わせ', 'https://twitter.com/819Chapchon', target: '_blank', rel: 'noopener noreferrer' %>
+    </nav>
+    <aside>
+        <p>Copyright © 2024</p>
+    </aside>
 </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -44,9 +44,6 @@
     </div>
 </nav>
 
-<% if controller_name == 'spots' && action_name == 'show' %>
-    <%= render "shared/spot_show_header" %>
-<% else %>
 <div class="fixed bottom-0 left-0 z-50 w-full h-16 bg-primary border-t border-primary-hover md:hidden">
     <div class="grid h-full max-w-lg grid-cols-5 mx-auto font-medium">
         <%= link_to map_spots_path, data: { turbo: false }, class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
@@ -71,4 +68,3 @@
         <% end %>
     </div>
 </div>
-<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -47,26 +47,26 @@
 <% if controller_name == 'spots' && action_name == 'show' %>
     <%= render "shared/spot_show_header" %>
 <% else %>
-<div class="fixed bottom-0 left-0 z-50 w-full h-12 bg-primary border-t border-primary-hover md:hidden">
+<div class="fixed bottom-0 left-0 z-50 w-full h-16 bg-primary border-t border-primary-hover md:hidden">
     <div class="grid h-full max-w-lg grid-cols-5 mx-auto font-medium">
         <%= link_to map_spots_path, data: { turbo: false }, class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
-            <i class="ph ph-magnifying-glass fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
+            <i class="ph-bold ph-magnifying-glass fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
             <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">検索</span>
         <% end %>
         <%= link_to spots_path, class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
-            <i class="ph ph-list-dashes fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
+            <i class="ph-bold ph-list-dashes fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
             <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">一覧</span>
         <% end %>
         <%= link_to start_diagnostics_path, class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
-        <i class="ph ph-paw-print fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
+        <i class="ph-fill ph-paw-print fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
             <span class="text-[9px] text-secondary group-hover:text-neutral">診断</span>
         <% end %>
         <%= link_to bookmarks_spots_path, method: :get, class: "inline-flex flex-col items-center justify-center px-1 hover:bg-gray-50 group" do %>
-            <i class="ph ph-heart fa-lg w-6 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
+            <i class="ph-bold ph-heart fa-lg w-6 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
             <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">保存/訪問済</span>
         <% end %>
         <%= link_to users_show_path(current_user), method: :get, class: "inline-flex flex-col items-center justify-center px-2 hover:bg-gray-50 group" do %>
-            <i class="ph ph-user-circle fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
+            <i class="ph-bold ph-user-circle fa-lg w-5 h-4 mt-2 text-secondary group-hover:text-neutral" aria-hidden="true"></i>
             <span class="text-[9px] text-secondary dark:text-gray-400 group-hover:text-neutral">Myページ</span>
         <% end %>
     </div>

--- a/app/views/shared/_spot_show_header.html.erb
+++ b/app/views/shared/_spot_show_header.html.erb
@@ -1,4 +1,4 @@
-<div class="fixed bottom-16 left-0 z-50 w-full h-16 bg-white border-primary-hover md:hidden" data-controller="modal login-modal">
+<div class="fixed bottom-16 left-0 z-30 w-full h-16 bg-white border-primary-hover md:hidden" data-controller="modal login-modal">
     <div class="grid h-full max-w-lg grid-cols-5 mx-auto font-medium">
         <% if user_signed_in? %>
         <%= link_to new_spot_review_path(@spot), class: "btn text-white text-[16px] ml-4 drop-shadow-md my-2 inline-flex flex-col col-span-4 items-center justify-center px-4 rounded-md bg-accent hover:bg-accent-hover hover:shadow-lg", data: { turbo_frame: 'review_modal' } do %>

--- a/app/views/shared/_spot_show_header.html.erb
+++ b/app/views/shared/_spot_show_header.html.erb
@@ -1,4 +1,4 @@
-<div class="fixed bottom-0 left-0 z-50 w-full h-16 bg-primary border-t border-primary-hover md:hidden" data-controller="modal login-modal">
+<div class="fixed bottom-16 left-0 z-50 w-full h-16 bg-white border-primary-hover md:hidden" data-controller="modal login-modal">
     <div class="grid h-full max-w-lg grid-cols-5 mx-auto font-medium">
         <% if user_signed_in? %>
         <%= link_to new_spot_review_path(@spot), class: "btn text-white text-[16px] ml-4 drop-shadow-md my-2 inline-flex flex-col col-span-4 items-center justify-center px-4 rounded-md bg-accent hover:bg-accent-hover hover:shadow-lg", data: { turbo_frame: 'review_modal' } do %>

--- a/app/views/spots/_index_spot_search.html.erb
+++ b/app/views/spots/_index_spot_search.html.erb
@@ -12,7 +12,7 @@
         </div>
         <div class="text-secondary flex-col items-center md:space-y-4">
             <div class="flex space-x-4 md:space-x-0 md:flex-col pt-4 pl-2 mb-4 md:mb-0">
-                <div class='label-select flex h-full md:text-sm text-xs space-x-2 items-center'>
+                <div class='label-select flex h-full text-sm space-x-2 items-center'>
                     <%= f.check_box :foster_parents_eq, { include_hidden: false, class: 'search-select text-sm checkbox checkbox-sm checkbox-secondary [--chkbg:theme(colors.secondary)] [--chkfg:white]' }, 1, nil %>
                     <%= f.label :foster_parents_eq, '里親募集あり', class: 'label font-semibold' %>
                 </div>

--- a/app/views/spots/_sidebar.html.erb
+++ b/app/views/spots/_sidebar.html.erb
@@ -1,4 +1,4 @@
-<button data-action="click->sidebar#toggleButton" aria-controls="default-sidebar" type="button" class="md:hidden fixed bottom-40 right-6 border-white rounded-full py-2 px-4 text-white bg-accent text-center hover:drop-shadow-none z-50" data-sidebar-target="toggleButton">
+<button data-action="click->sidebar#toggleButton" aria-controls="default-sidebar" type="button" class="md:hidden fixed bottom-44 right-6 border-white shadow-lg rounded-full py-2 px-4 text-white bg-accent text-center hover:drop-shadow-none z-50" data-sidebar-target="toggleButton">
   <i class="ph-bold ph-list-dashes" data-sidebar-target="icon"></i> <span data-sidebar-target="buttonText">リスト</span>
 </button>
 

--- a/app/views/spots/bookmarks.html.erb
+++ b/app/views/spots/bookmarks.html.erb
@@ -1,4 +1,7 @@
 <% content_for(:title, t('spots.bookmarks.title')) %>
+  <div id="flash">
+    <%= render 'layouts/flash_messages', flash: flash %>
+  </div>
 <div class="flex flex-col items-center justify-center w-full md:pt-24 md:bg-primary">
     <div class="md:w-11/12 w-full">
         <div data-controller="tabs rounded-t-lg" data-tabs-active-tab-class="-mb-px border-l border-t border-r rounded-t-lg">

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -86,7 +86,7 @@
                                                     end %>
                                             </span>
                                         </button>
-                                        <button class="btn join-item rounded-r-full border-y-primary border-r-primary border-l-primary-hover bg-primary hover:bg-primary" data-drawer-target="drawer-swipe" data-drawer-show="drawer-swipe" data-drawer-placement="bottom" data-drawer-edge="true" data-drawer-edge-offset="bottom-[60px]" data-drawer-backdrop="true" aria-controls="drawer-swipe" data-drawer-body-scrolling="true">
+                                        <button class="btn join-item rounded-r-full border-y-primary border-r-primary border-l-primary-hover hover:border-r-primary hover:bg-primary hover:border-y-primary bg-primary" data-drawer-target="drawer-swipe" data-drawer-show="drawer-swipe" data-drawer-placement="bottom" data-drawer-edge="true" data-drawer-edge-offset="bottom-[60px]" data-drawer-backdrop="true" aria-controls="drawer-swipe" data-drawer-body-scrolling="true">
                                             <i class="ph-bold ph-list-magnifying-glass fa-2xl text-primary-hover"></i>
                                             <span class="text-sm text-secondary dark:text-gray-400 group-hover:text-neutral">絞り込み</span>
                                         </button>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,4 +1,7 @@
 <% content_for(:title, t('spots.index.title')) %>
+  <div id="flash">
+    <%= render 'layouts/flash_messages', flash: flash %>
+  </div>
 <div class="flex flex-col items-center justify-center w-full md:pt-24 md:bg-primary">
     <div class="md:hidden fixed bottom-20 right-4 z-20">
         <button class="md:hidden bg-white right-4 btn w-10 h-6 border-none rounded-full items-center shadow-lg" onclick="my_modal_2.showModal()"><i class="ph-bold ph-question fa-2xl text-primary-hover"></i></button>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -1,7 +1,7 @@
 <% content_for(:title, t('spots.index.title')) %>
 <div class="flex flex-col items-center justify-center w-full md:pt-24 md:bg-primary">
-    <div class="md:hidden fixed bottom-16 right-4 z-20">
-        <button class="md:hidden bg-white right-4 btn w-12 h-9 border-none rounded-full items-center shadow-lg" onclick="my_modal_2.showModal()"><i class="ph-bold ph-question fa-2xl text-primary-hover"></i></button>
+    <div class="md:hidden fixed bottom-20 right-4 z-20">
+        <button class="md:hidden bg-white right-4 btn w-10 h-6 border-none rounded-full items-center shadow-lg" onclick="my_modal_2.showModal()"><i class="ph-bold ph-question fa-2xl text-primary-hover"></i></button>
     </div>
     <dialog id="my_modal_2" class="modal">
         <div class="modal-box">
@@ -72,8 +72,8 @@
                             </div>
                             <%= turbo_frame_tag "spots-list" do %>
                                 <div class="md:hidden" data-controller="dropdown">
-                                    <div class="join bg-primary rounded-full fixed bottom-16 left-[calc(50%-30px)] transform -translate-x-1/2 z-10" data-controller="sort">
-                                        <button tabindex="0" class="btn join-item border-primary-hover" data-action="dropdown#toggle click@window->dropdown#hide" data-sort-target="sortButton" data-current-sort="<%= @current_sort %>">
+                                    <div class="join bg-primary rounded-full shadow-lg fixed bottom-20 left-[calc(50%-30px)] transform -translate-x-1/2 z-10" data-controller="sort">
+                                        <button tabindex="0" class="btn join-item border-none" data-action="dropdown#toggle click@window->dropdown#hide" data-sort-target="sortButton" data-current-sort="<%= @current_sort %>">
                                             <i class="ph-bold ph-arrows-down-up fa-2xl text-primary-hover"></i>
                                             <span class="text-sm text-secondary dark:text-gray-400 group-hover:text-neutral">
                                                 <%= case @current_sort
@@ -83,14 +83,14 @@
                                                     end %>
                                             </span>
                                         </button>
-                                        <button class="btn join-item rounded-r-full border-primary-hover bg-primary hover:bg-primary" data-drawer-target="drawer-swipe" data-drawer-show="drawer-swipe" data-drawer-placement="bottom" data-drawer-edge="true" data-drawer-edge-offset="bottom-[60px]" data-drawer-backdrop="true" aria-controls="drawer-swipe" data-drawer-body-scrolling="true">
+                                        <button class="btn join-item rounded-r-full border-y-primary border-r-primary border-l-primary-hover bg-primary hover:bg-primary" data-drawer-target="drawer-swipe" data-drawer-show="drawer-swipe" data-drawer-placement="bottom" data-drawer-edge="true" data-drawer-edge-offset="bottom-[60px]" data-drawer-backdrop="true" aria-controls="drawer-swipe" data-drawer-body-scrolling="true">
                                             <i class="ph-bold ph-list-magnifying-glass fa-2xl text-primary-hover"></i>
                                             <span class="text-sm text-secondary dark:text-gray-400 group-hover:text-neutral">絞り込み</span>
                                         </button>
                                     </div>
                                     <ul  
                                     data-dropdown-target="menu"
-                                    class="hidden transition transform fixed bottom-28 z-10 w-52 bg-primary rounded-lg text-sm shadow-lg text-neutral"
+                                    class="hidden transition transform fixed bottom-32 z-10 w-32 bg-primary rounded-lg text-sm shadow-lg text-neutral"
                                     data-transition-enter-from="opacity-0 scale-95"
                                     data-transition-enter-to="opacity-100 scale-100"
                                     data-transition-leave-from="opacity-100 scale-100"
@@ -98,9 +98,9 @@
                                     data-sort-target="sortOptions"
                                     data-action="click->sort#updateSortLabel"
                                     >
-                                        <li class="w-full rounded-t-lg px-4 py-2 hover:bg-primary-hover"><%= sort_link(@q_spots, 'rating', '高評価', { default_order: :desc }) %></li>
-                                        <li class="w-full px-4 py-2 hover:bg-primary-hover"><%= sort_link(@q_spots, 'created_at desc', '新着順', { default_order: :desc }) %></li>
-                                        <li class="w-full rounded-b-lg px-4 py-2 hover:bg-primary-hover"><%= sort_link(@q_spots, 'created_at asc', '標準', { default_order: :asc }) %></li>
+                                        <li class="w-full rounded-t-lg px-4 py-4 hover:bg-primary-hover"><%= sort_link(@q_spots, 'rating', '高評価', { default_order: :desc }) %></li>
+                                        <li class="w-full px-4 py-4 hover:bg-primary-hover"><%= sort_link(@q_spots, 'created_at desc', '新着順', { default_order: :desc }) %></li>
+                                        <li class="w-full rounded-b-lg px-4 py-4 hover:bg-primary-hover"><%= sort_link(@q_spots, 'created_at asc', '標準', { default_order: :asc }) %></li>
                                     </ul>
                                 </div>
 
@@ -213,7 +213,7 @@
                                 <%= turbo_frame_tag "reviews-list" do %>
                                     <%= turbo_frame_tag 'tags_search' do %>
                                         <% if @reviews.present? %>
-                                            <button class="btn md:hidden w-1/2 fixed bottom-16 left-1/2 transform -translate-x-1/2 rounded-full border-primary-hover bg-primary hover:bg-primary z-10" data-drawer-target="review-drawer-swipe" data-drawer-show="review-drawer-swipe" data-drawer-placement="bottom" data-drawer-edge="true" data-drawer-edge-offset="bottom-[60px]" data-drawer-backdrop="true" aria-controls="review-drawer-swipe" data-drawer-body-scrolling="true">
+                                            <button class="btn md:hidden w-1/2 fixed bottom-20 left-1/2 transform -translate-x-1/2 rounded-full border-none shadow-lg bg-primary hover:bg-primary z-10" data-drawer-target="review-drawer-swipe" data-drawer-show="review-drawer-swipe" data-drawer-placement="bottom" data-drawer-edge="true" data-drawer-edge-offset="bottom-[60px]" data-drawer-backdrop="true" aria-controls="review-drawer-swipe" data-drawer-body-scrolling="true">
                                                 <i class="ph-bold ph-list-magnifying-glass fa-2xl text-primary-hover"></i>
                                                 <span class="text-sm text-secondary dark:text-gray-400 group-hover:text-neutral">絞り込み</span>
                                             </button>

--- a/app/views/spots/index.html.erb
+++ b/app/views/spots/index.html.erb
@@ -43,7 +43,8 @@
                             <%= render 'spots/index_spot_search' %>
                         </div>
                         <div class="md:col-span-3">
-                            <div class="flex justify-end items-center" data-controller="drawer">
+                            <%= turbo_frame_tag "spots-list" do %>
+                                                            <div class="flex justify-end items-center" data-controller="drawer">
                                 <div class="dropdown dropdown-end" data-controller="sort">
                                     <div tabindex="0" role="button" class="hidden md:btn m-1 bg-white border-none md:rounded-full items-center shadow-lg" data-sort-target="sortButton" data-current-sort="<%= @current_sort %>">
                                         <i class="ph-bold ph-arrows-down-up fa-2xl text-primary-hover"></i>
@@ -70,7 +71,6 @@
                                     </form>
                                 </dialog>
                             </div>
-                            <%= turbo_frame_tag "spots-list" do %>
                                 <div class="md:hidden" data-controller="dropdown">
                                     <div class="join bg-primary rounded-full shadow-lg fixed bottom-20 left-[calc(50%-30px)] transform -translate-x-1/2 z-10" data-controller="sort">
                                         <button tabindex="0" class="btn join-item border-none" data-action="dropdown#toggle click@window->dropdown#hide" data-sort-target="sortButton" data-current-sort="<%= @current_sort %>">
@@ -113,8 +113,8 @@
                                     </div>
                                     <%= render 'spots/index_spot_search' %>
                                 </div>
-                                <% if params[:q].present? && params[:q][:s].blank? %>
-                                    <div class="flex justify-start items-center md:px-8 max-[600px]:w-full max-[600px]:border-b-2 md:mt-8">
+                                <% if params[:q].present? && has_search_conditions?(params) %>
+                                    <div class="flex justify-start items-center md:px-8 mt-4 max-[600px]:w-full max-[600px]:border-b-2 md:mt-8">
                                         <div class="text-sm text-secondary">
                                             <p class="text-lg"><span class="text-neutral text-xl font-semibold"><%= @spots_count %>件</span>&ensp;「<%= search_conditions(params) %>」の検索結果</p>
                                         </div>

--- a/app/views/spots/map.html.erb
+++ b/app/views/spots/map.html.erb
@@ -1,4 +1,7 @@
 <% content_for(:title, t('spots.map.title')) %>
+  <div id="flash">
+    <%= render 'layouts/flash_messages', flash: flash %>
+  </div>
 <div class="hidden md:block md:ml-64 md:mt-4">
   <%= render 'layouts/flash_messages', flash: flash %>
 </div>

--- a/app/views/spots/map.html.erb
+++ b/app/views/spots/map.html.erb
@@ -99,7 +99,7 @@
                   </div>
                   <div class="flex flex-wrap">
                     <div class="p-4 flex flex-col h-full md:p-7">
-                      <h3 id="spotName-<%= spot.id %>" class="md:text-lg px-2 font-bold text-sm text-neutral font-zenmaru md:px-1.5 overflow-hidden w-full whitespace-nowrap text-overflow-ellipsis break-words whitespace-pre-wrap"></h3>
+                      <h3 id="spotName-<%= spot.id %>" class="md:text-lg px-2 font-bold text-sm text-neutral font-zenmaru md:px-1.5 overflow-hidden w-full whitespace-pre-wrap pr-1 line-clamp-1"></h3>
                       <div class="justify-start flex md:space-x-4 space-x-2 mt-2">
                         <div class="inline-flex">
                           <p id="spotCategory-<%= spot.id %>" class="hidden md:block text-xs text-white py-1 px-2 rounded-full bg-accent dark:text-neutral-500"></p>

--- a/app/views/spots/map.html.erb
+++ b/app/views/spots/map.html.erb
@@ -86,7 +86,7 @@
             </div>
           </div>
           <!-- infoCard -->
-          <div class="flex flex-col items-center justify-center md:my-8 md:bottom-0 w-full fixed bottom-14 md:static">
+          <div class="flex flex-col items-center justify-center md:my-8 md:bottom-0 w-full shadow-lg md:shadow-none fixed bottom-20 md:static">
             <% @spots.each do |spot| %>
               <%= link_to spot_path(spot), data: { turbo: false }, class: "w-11/12 rounded-xl infoCard-link" do %>
                 <div id="infoCard-<%= spot.id %>" class="hidden bg-white border rounded-xl shadow-sm flex mx-auto w-11/12 md:w-full absolute md:relative bottom-0 inset-x-0 z-10 md:mb-50 hover:shadow-lg group">

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -1,8 +1,8 @@
 <% content_for(:title, @spot.name) %>
 <% assign_meta_tags title: @spot.name, image: @image_url %>
-<nav class="md:hidden w-full h-12 ">
-    <div class="navbar bg-primary text-secondary border-b border-primary-hover">
-        <div class="flex-1 items-center mb-3">
+<nav class="md:hidden w-full h-12 fixed top-0 z-10">
+    <div class="navbar bg-primary text-secondary border-b border-primary-hover items-center">
+        <div class="flex-1 items-center">
           <%= link_to "", class: "back-link", data: { turbo: false, excluded_paths: [user_line_omniauth_authorize_path, user_google_oauth2_omniauth_authorize_path].to_json } do %>
             <i class="ph-light ph-caret-left fa-2xl text-secondary group-hover:text-neutral" aria-hidden="true"></i>
           <% end %>
@@ -10,8 +10,10 @@
     </div>
 </nav>
 
-<% flash.empty? ? flash_class = "md:mt-16" : flash_class = "" %>
-<div class="bg-primary relative md:pb-16 md:mb-0 mb-20 <%= flash_class %>" data-controller="login-modal">
+<div class="bg-primary relative mt-12 md:pb-16 md:mb-0 mb-20" data-controller="login-modal">
+  <div id="flash" class="mt-16">
+    <%= render 'layouts/flash_messages', flash: flash %>
+  </div>
   <div class="swiper mySwiper">
     <div class="swiper-wrapper">
     <% if @prioritized_image.present? %>

--- a/app/views/spots/show.html.erb
+++ b/app/views/spots/show.html.erb
@@ -224,6 +224,7 @@
     </div>
   </div>
 </div>
+<%= render "shared/spot_show_header" %>
 
 <% if user_signed_in? %>
   <%= link_to new_spot_review_path(@spot), data: { turbo_frame: 'review_modal' } do %>

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -1,3 +1,6 @@
+<div id="flash">
+  <%= render 'layouts/flash_messages', flash: flash %>
+</div>
 <div data-controller="login-modal">
   <div class="mx-auto max-w-screen-2xl px-4">
     <header id="fixed-text" class=" fixed top-0 left-0 z-50 w-full">

--- a/app/views/static_pages/privacy_policy.html.erb
+++ b/app/views/static_pages/privacy_policy.html.erb
@@ -1,4 +1,7 @@
 <% content_for(:title, t('static_pages.privacy_policy.title')) %>
+<div id="flash">
+  <%= render 'layouts/flash_messages', flash: flash %>
+</div>
 <section class="text-secondary bg-primary body-font">
   <div class="container px-5 py-24 mx-auto">
     <div class="flex flex-wrap w-full mb-20 md:ml-10">

--- a/app/views/static_pages/terms_of_use.html.erb
+++ b/app/views/static_pages/terms_of_use.html.erb
@@ -1,4 +1,7 @@
 <% content_for(:title, t('static_pages.terms_of_use.title')) %>
+<div id="flash">
+  <%= render 'layouts/flash_messages', flash: flash %>
+</div>
 <section class="text-secondary body-font bg-primary">
   <div class="container px-5 py-24 mx-auto">
     <div class="flex flex-wrap w-full mb-20 md:ml-10">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,4 +1,7 @@
 <% content_for(:title, t('users.show.title')) %>
+<div id="flash">
+    <%= render 'layouts/flash_messages', flash: flash %>
+</div>
 <div class="bg-primary md:pb-16 md:mb-0 mb-20">
     <div class="flex flex-col items-center justify-center w-full md:pt-20">
         <div class="md:w-11/12 w-full">

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,6 +12,7 @@ ja:
         rating: '評価'
         body: 'コメント'
         images: ''
+        tags: ''
       spot:
         foster_parents:
           no_recruitment: '里親募集なし'


### PR DESCRIPTION
# 概要
## やったこと
- [x] フッターのpbを増やす(PWAした時にMap下部が切れる)
- [x] infoCardのスポット名をはみ出る部分は...にする
- [x] ソートした時も検索条件を表示し続けるようにする
- [x] 一覧検索の検索パネルがスワイプで閉じるようにする
- [x] スポット詳細のヘッダーを上部に固定する
- [x] タグの投稿数を制限する