### PR TITLE
🐛 Fix:require 'aws-sdk-s3'の記載を追加

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/integer/time"
+require 'aws-sdk-s3'
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.


### PR DESCRIPTION
`config/environments/production.rb`に`require 'aws-sdk-s3'`の記載を追加